### PR TITLE
Convert words to string before downcase to avoid type conversion errors.

### DIFF
--- a/lib/zxcvbn/dictionary_ranker.rb
+++ b/lib/zxcvbn/dictionary_ranker.rb
@@ -14,7 +14,7 @@ module Zxcvbn
       dictionary = {}
       i = 1
       words.each do |word|
-        dictionary[word.downcase] = i
+        dictionary[word.to_s.downcase] = i
         i += 1
       end
       dictionary


### PR DESCRIPTION
I was receiving the following error on initialisation of the gem:

```
ruby-1.9.2-p320/gems/zxcvbn-ruby-0.0.2/lib/zxcvbn/dictionary_ranker.rb:17:in `block in rank_dictionary': undefined method 'downcase' for 98765.0:Float (NoMethodError)
```

It seems that there was some automatic conversion of some dictionary words into `Float` type. This was fixed by explicitly converting each word to a string before executing `downcase`.
