### PR TITLE
Switch to a non-memory-retaining API for password testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ruby port of [zxcvbn.js](https://github.com/dropbox/zxcvbn)
 Gemfile:
 
 ```ruby
-gem "zxcvbn-ruby", :require => 'zxcvbn'
+gem 'zxcvbn-ruby', require: 'zxcvbn'
 ```
 
 Example usage:
@@ -19,5 +19,21 @@ $ irb
 >> Zxcvbn.test('@lfred2004', ['alfred'])
 => #<Zxcvbn::Score:0x007fd467803098 @entropy=7.895, @crack_time=0.012, @crack_time_display="instant", @score=0, @match_sequence=[#<Zxcvbn::Match matched_word="alfred", token="@lfred", i=0, j=5, rank=1, pattern="dictionary", dictionary_name="user_inputs", l33t=true, sub={"@"=>"a"}, sub_display"@ -> a", base_entropy0.0, uppercase_entropy0.0, l33t_entropy1, entropy1.0, #<Zxcvbn::Match i=6, j=9, token="2004", pattern="year", entropy=6.894817763307944], @password="@lfred2004", @calc_time=0.003436>
 >> Zxcvbn.test('asdfghju7654rewq', ['alfred'])
+=> #<Zxcvbn::Score:0x007fd4689c1168 @entropy=29.782, @crack_time=46159.451, @crack_time_display="14 hours", @score=2, @match_sequence=[#<Zxcvbn::Match pattern="spatial", i=0, j=15, token="asdfghju7654rewq", graph="qwerty", turns=5, shifted_count=0, entropy=29.7820508329166>], password"asdfghju7654rewq", calc_time0.00526
+```
+
+## Testing Multiple Passwords
+
+The dictionaries used for password strength testing are loaded each request to `Zxcvbn.test`. If you you'd prefer to persist the dictionaries in memory (approx 20MB RSS) to perform lots of password tests in succession then you can use the `Zxcvbn::Tester` API:
+
+```ruby
+$ irb
+>> require 'zxcvbn'
+=> true
+>> tester = Zxcvbn::Tester.new
+=> #<Zxcvbn::Tester:0x3fe99d869aa4>
+>> tester.test('@lfred2004', ['alfred'])
+=> #<Zxcvbn::Score:0x007fd4689c1168 @entropy=29.782, @crack_time=46159.451, @crack_time_display="14 hours", @score=2, @match_sequence=[#<Zxcvbn::Match pattern="spatial", i=0, j=15, token="asdfghju7654rewq", graph="qwerty", turns=5, shifted_count=0, entropy=29.7820508329166>], password"asdfghju7654rewq", calc_time0.00526
+>> tester.test('@lfred2004', ['alfred'])
 => #<Zxcvbn::Score:0x007fd4689c1168 @entropy=29.782, @crack_time=46159.451, @crack_time_display="14 hours", @score=2, @match_sequence=[#<Zxcvbn::Match pattern="spatial", i=0, j=15, token="asdfghju7654rewq", graph="qwerty", turns=5, shifted_count=0, entropy=29.7820508329166>], password"asdfghju7654rewq", calc_time0.00526
 ```

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -8,6 +8,10 @@ module Zxcvbn
   DATA_PATH = Pathname(File.expand_path('../../data', __FILE__))
 
   # Returns a Zxcvbn::Score for the given password
+  #
+  # Example:
+  #
+  #   Zxcvbn.test("password").score #=> 0
   def test(password, user_inputs = [], word_lists = {})
     tester = Tester.new
     tester.add_word_lists(word_lists)

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -1,46 +1,16 @@
-require 'json'
 require 'pathname'
-
 require 'zxcvbn/version'
-require 'zxcvbn/match'
-require 'zxcvbn/matchers/regex_helpers'
-require 'zxcvbn/matchers/dictionary'
-require 'zxcvbn/matchers/l33t'
-require 'zxcvbn/matchers/spatial'
-require 'zxcvbn/matchers/sequences'
-require 'zxcvbn/matchers/repeat'
-require 'zxcvbn/matchers/digits'
-require 'zxcvbn/matchers/year'
-require 'zxcvbn/matchers/date'
-require 'zxcvbn/dictionary_ranker'
-require 'zxcvbn/omnimatch'
-require 'zxcvbn/math'
-require 'zxcvbn/entropy'
-require 'zxcvbn/crack_time'
-require 'zxcvbn/score'
-require 'zxcvbn/scorer'
-require 'zxcvbn/password_strength'
+require 'zxcvbn/tester'
 
 module Zxcvbn
   extend self
 
   DATA_PATH = Pathname(File.expand_path('../../data', __FILE__))
-  ADJACENCY_GRAPHS = JSON.load(DATA_PATH.join('adjacency_graphs.json').read)
-  FREQUENCY_LISTS_PATH = DATA_PATH.join("frequency_lists")
-  RANKED_DICTIONARIES = DictionaryRanker.rank_dictionaries(
-    "english" =>      FREQUENCY_LISTS_PATH.join("english.txt").read.split,
-    "female_names" => FREQUENCY_LISTS_PATH.join("female_names.txt").read.split,
-    "male_names" =>   FREQUENCY_LISTS_PATH.join("male_names.txt").read.split,
-    "passwords" =>    FREQUENCY_LISTS_PATH.join("passwords.txt").read.split,
-    "surnames" =>     FREQUENCY_LISTS_PATH.join("surnames.txt").read.split
-  )
 
-  def test(password, user_inputs = [])
-    zxcvbn = PasswordStrength.new
-    zxcvbn.test(password, user_inputs)
-  end
-
-  def add_word_list(name, list)
-    RANKED_DICTIONARIES[name] = DictionaryRanker.rank_dictionary(list)
+  # Returns a Zxcvbn::Score for the given password
+  def test(password, user_inputs = [], word_lists = {})
+    tester = Tester.new
+    tester.add_word_lists(word_lists)
+    tester.test(password, user_inputs)
   end
 end

--- a/lib/zxcvbn/crack_time.rb
+++ b/lib/zxcvbn/crack_time.rb
@@ -1,51 +1,53 @@
-module Zxcvbn::CrackTime
-  SINGLE_GUESS = 0.010
-  NUM_ATTACKERS = 100
+module Zxcvbn
+  module CrackTime
+    SINGLE_GUESS = 0.010
+    NUM_ATTACKERS = 100
 
-  SECONDS_PER_GUESS = SINGLE_GUESS / NUM_ATTACKERS
+    SECONDS_PER_GUESS = SINGLE_GUESS / NUM_ATTACKERS
 
-  def entropy_to_crack_time(entropy)
-    0.5 * (2 ** entropy) * SECONDS_PER_GUESS
-  end
-
-  def crack_time_to_score(seconds)
-    case
-    when seconds < 10**2
-      0
-    when seconds < 10**4
-      1
-    when seconds < 10**6
-      2
-    when seconds < 10**8
-      3
-    else
-      4
+    def entropy_to_crack_time(entropy)
+      0.5 * (2 ** entropy) * SECONDS_PER_GUESS
     end
-  end
 
-  def display_time(seconds)
-    minute  = 60
-    hour    = minute * 60
-    day     = hour * 24
-    month   = day * 31
-    year    = month * 12
-    century = year * 100
+    def crack_time_to_score(seconds)
+      case
+      when seconds < 10**2
+        0
+      when seconds < 10**4
+        1
+      when seconds < 10**6
+        2
+      when seconds < 10**8
+        3
+      else
+        4
+      end
+    end
 
-    case
-    when seconds < minute
-      'instant'
-    when seconds < hour
-      "#{1 + (seconds / minute).ceil} minutes"
-    when seconds < day
-      "#{1 + (seconds / hour).ceil} hours"
-    when seconds < month
-      "#{1 + (seconds / day).ceil} days"
-    when seconds < year
-      "#{1 + (seconds / month).ceil} months"
-    when seconds < century
-      "#{1 + (seconds / year).ceil} years"
-    else
-      'centuries'
+    def display_time(seconds)
+      minute  = 60
+      hour    = minute * 60
+      day     = hour * 24
+      month   = day * 31
+      year    = month * 12
+      century = year * 100
+
+      case
+      when seconds < minute
+        'instant'
+      when seconds < hour
+        "#{1 + (seconds / minute).ceil} minutes"
+      when seconds < day
+        "#{1 + (seconds / hour).ceil} hours"
+      when seconds < month
+        "#{1 + (seconds / day).ceil} days"
+      when seconds < year
+        "#{1 + (seconds / month).ceil} months"
+      when seconds < century
+        "#{1 + (seconds / year).ceil} years"
+      else
+        'centuries'
+      end
     end
   end
 end

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -1,0 +1,29 @@
+require 'json'
+require 'zxcvbn/dictionary_ranker'
+
+module Zxcvbn
+  class Data
+    def initialize
+      @ranked_dictionaries = DictionaryRanker.rank_dictionaries(
+        "english" =>      read_word_list("english.txt"),
+        "female_names" => read_word_list("female_names.txt"),
+        "male_names" =>   read_word_list("male_names.txt"),
+        "passwords" =>    read_word_list("passwords.txt"),
+        "surnames" =>     read_word_list("surnames.txt")
+      )
+      @adjacency_graphs = JSON.load(DATA_PATH.join('adjacency_graphs.json').read)
+    end
+
+    attr_reader :ranked_dictionaries, :adjacency_graphs
+
+    def add_word_list(name, list)
+      @ranked_dictionaries[name] = DictionaryRanker.rank_dictionary(list)
+    end
+
+    private
+
+    def read_word_list(file)
+      DATA_PATH.join("frequency_lists", file).read.split
+    end
+  end
+end

--- a/lib/zxcvbn/dictionary_ranker.rb
+++ b/lib/zxcvbn/dictionary_ranker.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 module Zxcvbn
   class DictionaryRanker
     def self.rank_dictionaries(lists)

--- a/lib/zxcvbn/entropy.rb
+++ b/lib/zxcvbn/entropy.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/math'
+
 module Zxcvbn::Entropy
   include Zxcvbn::Math
 

--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/matchers/regex_helpers'
+
 module Zxcvbn
   module Matchers
     class Date

--- a/lib/zxcvbn/matchers/dictionary.rb
+++ b/lib/zxcvbn/matchers/dictionary.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/match'
+
 module Zxcvbn
   module Matchers
     # Given a password and a dictionary, match on any sequential segment of

--- a/lib/zxcvbn/matchers/digits.rb
+++ b/lib/zxcvbn/matchers/digits.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/matchers/regex_helpers'
+
 module Zxcvbn
   module Matchers
     class Digits

--- a/lib/zxcvbn/matchers/regex_helpers.rb
+++ b/lib/zxcvbn/matchers/regex_helpers.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/match'
+
 module Zxcvbn
   module Matchers
     module RegexHelpers

--- a/lib/zxcvbn/matchers/repeat.rb
+++ b/lib/zxcvbn/matchers/repeat.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/match'
+
 module Zxcvbn
   module Matchers
     class Repeat

--- a/lib/zxcvbn/matchers/sequences.rb
+++ b/lib/zxcvbn/matchers/sequences.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/match'
+
 module Zxcvbn
   module Matchers
     class Sequences

--- a/lib/zxcvbn/matchers/spatial.rb
+++ b/lib/zxcvbn/matchers/spatial.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/match'
+
 module Zxcvbn
   module Matchers
     class Spatial

--- a/lib/zxcvbn/matchers/year.rb
+++ b/lib/zxcvbn/matchers/year.rb
@@ -1,3 +1,5 @@
+require 'zxcvbn/matchers/regex_helpers'
+
 module Zxcvbn
   module Matchers
     class Year

--- a/lib/zxcvbn/math.rb
+++ b/lib/zxcvbn/math.rb
@@ -41,14 +41,14 @@ module Zxcvbn
     end
 
     def average_degree_for_graph(graph_name)
-      graph = Zxcvbn::ADJACENCY_GRAPHS[graph_name]
+      graph = data.adjacency_graphs[graph_name]
       degrees = graph.map { |_, neighbors| neighbors.compact.size }
       sum = degrees.inject(0, :+)
       sum.to_f / graph.size
     end
 
     def starting_positions_for_graph(graph_name)
-      Zxcvbn::ADJACENCY_GRAPHS[graph_name].length
+      data.adjacency_graphs[graph_name].length
     end
   end
 end

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -1,6 +1,17 @@
+require 'zxcvbn/dictionary_ranker'
+require 'zxcvbn/matchers/dictionary'
+require 'zxcvbn/matchers/l33t'
+require 'zxcvbn/matchers/spatial'
+require 'zxcvbn/matchers/digits'
+require 'zxcvbn/matchers/repeat'
+require 'zxcvbn/matchers/sequences'
+require 'zxcvbn/matchers/year'
+require 'zxcvbn/matchers/date'
+
 module Zxcvbn
   class Omnimatch
-    def initialize
+    def initialize(data)
+      @data = data
       @matchers = build_matchers
     end
 
@@ -24,14 +35,14 @@ module Zxcvbn
 
     def build_matchers
       matchers = []
-      dictionary_matchers = RANKED_DICTIONARIES.map do |name, dictionary|
+      dictionary_matchers = @data.ranked_dictionaries.map do |name, dictionary|
         Matchers::Dictionary.new(name, dictionary)
       end
       l33t_matcher = Matchers::L33t.new(dictionary_matchers)
       matchers += dictionary_matchers
       matchers += [
         l33t_matcher,
-        Matchers::Spatial.new(ADJACENCY_GRAPHS),
+        Matchers::Spatial.new(@data.adjacency_graphs),
         Matchers::Digits.new,
         Matchers::Repeat.new,
         Matchers::Sequences.new,

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -1,10 +1,12 @@
 require 'benchmark'
+require 'zxcvbn/omnimatch'
+require 'zxcvbn/scorer'
 
 module Zxcvbn
   class PasswordStrength
-    def initialize
-      @omnimatch = Omnimatch.new
-      @scorer = Scorer.new
+    def initialize(data)
+      @omnimatch = Omnimatch.new(data)
+      @scorer = Scorer.new(data)
     end
 
     def test(password, user_inputs = [])

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -1,5 +1,16 @@
+require 'zxcvbn/entropy'
+require 'zxcvbn/crack_time'
+require 'zxcvbn/score'
+require 'zxcvbn/match'
+
 module Zxcvbn
   class Scorer
+    def initialize(data)
+      @data = data
+    end
+
+    attr_reader :data
+
     include Entropy
     include CrackTime
 

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -1,0 +1,31 @@
+require 'zxcvbn/data'
+require 'zxcvbn/password_strength'
+
+module Zxcvbn
+  # Allows you to test the strength of multiple passwords without reading and
+  # parsing the dictionary data from disk each test. Dictionary data is read
+  # once from disk and stored in memory for the life of the Tester object.
+  #
+  # Examples:
+  #
+  #   tester = Zxcvbn::Tester.new
+  #
+  #   tester.add_word_lists("custom" => ["words"])
+  #
+  #   tester.test("password 1")
+  #   tester.test("password 2")
+  #   tester.test("password 3")
+  class Tester
+    def initialize
+      @data = Data.new
+    end
+
+    def test(password, user_inputs = [])
+      PasswordStrength.new(@data).test(password, user_inputs)
+    end
+
+    def add_word_lists(lists)
+      lists.each_pair {|name, words| @data.add_word_list(name, words)}
+    end
+  end
+end

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -27,5 +27,9 @@ module Zxcvbn
     def add_word_lists(lists)
       lists.each_pair {|name, words| @data.add_word_list(name, words)}
     end
+
+    def inspect
+      "#<#{self.class}:0x#{self.__id__.to_s(16)}>"
+    end
   end
 end

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -6,7 +6,7 @@ module Zxcvbn
   # parsing the dictionary data from disk each test. Dictionary data is read
   # once from disk and stored in memory for the life of the Tester object.
   #
-  # Examples:
+  # Example:
   #
   #   tester = Zxcvbn::Tester.new
   #

--- a/spec/matchers/dictionary_spec.rb
+++ b/spec/matchers/dictionary_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Zxcvbn::Matchers::Dictionary do
   let(:matcher) { described_class.new('english', dictionary) }
-  let(:dictionary) { Zxcvbn::RANKED_DICTIONARIES['english'] }
+  let(:dictionary) { Zxcvbn::Data.new.ranked_dictionaries['english'] }
 
   it 'finds all the matches' do
     matches = matcher.matches('whatisinit')

--- a/spec/matchers/l33t_spec.rb
+++ b/spec/matchers/l33t_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Zxcvbn::Matchers::L33t do
   let(:matcher) { described_class.new([dictionary_matcher]) }
-  let(:dictionary) { Zxcvbn::RANKED_DICTIONARIES['english'] }
+  let(:dictionary) { Zxcvbn::Data.new.ranked_dictionaries['english'] }
   let(:dictionary_matcher) { Zxcvbn::Matchers::Dictionary.new('english', dictionary) }
 
   describe '#relevant_l33t_substitutions' do

--- a/spec/matchers/spatial_spec.rb
+++ b/spec/matchers/spatial_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Zxcvbn::Matchers::Spatial do
   let(:matcher) { Zxcvbn::Matchers::Spatial.new(graphs) }
-  let(:graphs)  { Zxcvbn::ADJACENCY_GRAPHS }
+  let(:graphs)  { Zxcvbn::Data.new.adjacency_graphs }
 
   describe '#matches' do
     let(:matches) { matcher.matches('rtyikm') }

--- a/spec/omnimatch_spec.rb
+++ b/spec/omnimatch_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Zxcvbn::Omnimatch do
   before(:all) do
-    @omnimatch = described_class.new
+    @omnimatch = described_class.new(Zxcvbn::Data.new)
   end
 
   def omnimatch(password)

--- a/spec/scoring/entropy_spec.rb
+++ b/spec/scoring/entropy_spec.rb
@@ -6,6 +6,9 @@ describe Zxcvbn::Entropy do
   let(:entropy) {
     Class.new do
       include Zxcvbn::Entropy
+      def data
+        Zxcvbn::Data.new
+      end
     end.new
   }
 
@@ -163,7 +166,7 @@ describe Zxcvbn::Entropy do
     context 'when keyboard is qwerty' do
       it 'should return the correct entropy' do
         match.graph = 'qwerty'
-        
+
         entropy.spatial_entropy(match).should eql 11.562242424221074
       end
     end

--- a/spec/scoring/math_spec.rb
+++ b/spec/scoring/math_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe Zxcvbn::Math do
   include Zxcvbn::Math
 
+  def data
+    Zxcvbn::Data.new
+  end
+
   describe '#bruteforce_cardinality' do
     context 'when empty password' do
       it 'should return 0 if empty password' do

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Zxcvbn::Tester do
+  let(:tester) { Zxcvbn::Tester.new }
+
+  TEST_PASSWORDS.each do |password|
+    it "gives back the same score for #{password}" do
+      ruby_result = tester.test(password)
+      js_result = js_zxcvbn(password)
+
+      ruby_result.calc_time.should_not be_nil
+      ruby_result.password.should eq js_result['password']
+      ruby_result.entropy.should eq js_result['entropy']
+      ruby_result.crack_time.should eq js_result['crack_time']
+      ruby_result.crack_time_display.should eq js_result['crack_time_display']
+      ruby_result.score.should eq js_result['score']
+      ruby_result.pattern.should eq js_result['pattern']
+      ruby_result.match_sequence.count.should eq js_result['match_sequence'].count
+    end
+  end
+
+  context 'with a custom user dictionary' do
+    it 'scores them against the user dictionary' do
+      result = tester.test('themeforest', ['themeforest'])
+      result.entropy.should eq 0
+      result.score.should eq 0
+    end
+
+    it 'matches l33t substitutions on this dictionary' do
+      result = tester.test('th3m3for3st', ['themeforest'])
+      result.entropy.should eq 1
+      result.score.should eq 0
+    end
+  end
+
+  context 'with a custom global dictionary' do
+    before { tester.add_word_lists('envato' => ['envato']) }
+
+    it 'scores them against the dictionary' do
+      result = tester.test('envato')
+      result.entropy.should eq 0
+      result.score.should eq 0
+    end
+  end
+
+  context 'nil password' do
+    specify do
+      expect { tester.test(nil) }.to_not raise_error
+    end
+  end
+end

--- a/spec/zxcvbn_spec.rb
+++ b/spec/zxcvbn_spec.rb
@@ -1,49 +1,24 @@
 require 'spec_helper'
 
-describe 'zxcvbn over a set of example passwords' do
-  TEST_PASSWORDS.each do |password|
-    it "gives back the same score for #{password}" do
-      ruby_result = Zxcvbn.test(password)
-      js_result = js_zxcvbn(password)
-
-      ruby_result.calc_time.should_not be_nil
-      ruby_result.password.should eq js_result['password']
-      ruby_result.entropy.should eq js_result['entropy']
-      ruby_result.crack_time.should eq js_result['crack_time']
-      ruby_result.crack_time_display.should eq js_result['crack_time_display']
-      ruby_result.score.should eq js_result['score']
-      ruby_result.pattern.should eq js_result['pattern']
-      ruby_result.match_sequence.count.should eq js_result['match_sequence'].count
+describe 'Zxcvbn.test' do
+  context 'with a password' do
+    it 'returns a result' do
+      result = Zxcvbn.test('password')
+      expect(result.entropy).to_not be_nil
     end
   end
 
-  context 'with a custom user dictionary' do
-    it 'scores them against the user dictionary' do
-      result = Zxcvbn.test('themeforest', ['themeforest'])
-      result.entropy.should eq 0
-      result.score.should eq 0
-    end
-
-    it 'matches l33t substitutions on this dictionary' do
-      result = Zxcvbn.test('th3m3for3st', ['themeforest'])
-      result.entropy.should eq 1
-      result.score.should eq 0
+  context 'with a password and user input' do
+    it 'returns a result' do
+      result = Zxcvbn.test('password', ['inputs'])
+      expect(result.entropy).to_not be_nil
     end
   end
 
-  context 'with a custom global dictionary' do
-    before { Zxcvbn.add_word_list('envato', ['envato']) }
-
-    it 'scores them against the dictionary' do
-      result = Zxcvbn.test('envato')
-      result.entropy.should eq 0
-      result.score.should eq 0
-    end
-  end
-
-  context 'nil password' do
-    specify do
-      expect { Zxcvbn.test(nil) }.to_not raise_error
+  context 'with a password, user input and custom word lists' do
+    it 'returns a result' do
+      result = Zxcvbn.test('password', ['inputs'], {'list' => ['words']})
+      expect(result.entropy).to_not be_nil
     end
   end
 end


### PR DESCRIPTION
TLDR;

* Loads the dictionaries and adjacency graph on demand (reducing retained memory)
* Adds a `Zxcvbn::Tester` for performance-sensitive use cases (for old behaviour)
* Changes to `add_word_lists(key=>val)` from `add_word_list(key,val)`

At the moment we're loading all the dictionary and adjacency graph data when the library is required, and storing it in a constant. This makes for slow load times for Rails applications, and a huge chunk of retained memory. For our Rails application it's the biggest retained memory by gem after ActiveSupport.

The API stays the same:

```ruby
Zxcvbn::Tester.test("password")
```

The change is that `Zxcvbn.test` now loads the dictionary on demand, and doesn't retain it in memory afterwards. This has the advantage of not adding overhead to applications when they add `gem "zxcvbn"` to their Gemfile, and that the base memory usage for the application is much lower. The disadvantage is that is will take longer to test an individual password.

For performance sensitive use cases where retained memory is not an issue, I've added a `Zxcvbn::Tester` class that you can instantiate once (on application initialisation if you wished), for example:

```ruby
tester = Zxcvbn::Tester.new
tester.add_word_lists("custom" => ["words"])
tester.test("password 1")
tester.test("password 2")
tester.test("password 3")
```

For the basic case of `Zxcvbn.test("password")` it will simply load the dictionaries, test the password, and release the memory.

Before this change:

* require allocates 264,315 objects (21MB of memory), retains 87120 objects (6.8MB of memory)
* password test doesn't allocate many objects or retain memory (all happens on require)

```
$ time ruby -I./lib -e ''
real	0m0.176s
user	0m0.090s
sys	0m0.081s

$ time ruby -I./lib -e 'require "zxcvbn"'
real	0m0.325s
user	0m0.219s
sys	0m0.100s

$ ruby -I./lib -rmemory_profiler -e 'puts MemoryProfiler.report { require "zxcvbn" }.pretty_print'
Total allocated 264315
Total retained 87120

allocated memory by gem
-----------------------------------
zxcvbn-ruby/lib x 21126753
rubygems x 602449
json-1.8.2 x 348926
2.2.0/lib x 34868
2.2.0 x 18275
other x 80

$ time ruby -I./lib -rzxcvbn -e 'Zxcvbn.test("password")'
real	0m0.329s
user	0m0.221s
sys	0m0.101s

$ ruby -I./lib -rmemory_profiler -e 'puts MemoryProfiler.report { require "zxcvbn"; Zxcvbn.test("password") }.pretty_print'
Total allocated 265702
Total retained 87123

allocated memory by gem
-----------------------------------
zxcvbn-ruby/lib x 21198553
rubygems x 602369
json-1.8.2 x 348926
2.2.0/lib x 77508
2.2.0 x 18275
other x 160

retained memory by gem
-----------------------------------
zxcvbn-ruby/lib x 6813690
json-1.8.2 x 261837
rubygems x 57182
2.2.0 x 4921
2.2.0/lib x 1649

retained objects by gem
-----------------------------------
zxcvbn-ruby/lib x 85166
json-1.8.2 x 1261
rubygems x 637
2.2.0 x 42
2.2.0/lib x 19
```

After this change:

* require allocates 127 objects (0.01MB of memory), retains 0.006MB
* password test allocates 256,268 objects (21MB of memory), retains 79 objects (0.006MB of memory)

```
$ time ruby -I./lib -e ''
real	0m0.176s
user	0m0.090s
sys	0m0.081s

$ time ruby -I./lib -e 'require "zxcvbn"'
real	0m0.214s
user	0m0.121s
sys	0m0.090s

$ ruby -I./lib -rmemory_profiler -e 'puts MemoryProfiler.report { require "zxcvbn"; }.pretty_print'
Total allocated 7579
Total retained 806

allocated memory by gem
-----------------------------------
rubygems x 621383
json-1.8.2 x 70463
2.2.0 x 18275
2.2.0/lib x 14985
zxcvbn-ruby/lib x 10570
other x 80

allocated objects by gem
-----------------------------------
rubygems x 6233
json-1.8.2 x 878
2.2.0 x 178
2.2.0/lib x 162
zxcvbn-ruby/lib x 127
other x 1

retained memory by gem
-----------------------------------
rubygems x 59752
zxcvbn-ruby/lib x 6490
2.2.0 x 4921
json-1.8.2 x 1214
2.2.0/lib x 880

$ time ruby -I./lib -rzxcvbn -e 'Zxcvbn.test("password")'
real	0m0.324s
user	0m0.221s
sys	0m0.098s

$ ruby -I./lib -rmemory_profiler -e 'puts MemoryProfiler.report { require "zxcvbn"; Zxcvbn.test("password") }.pretty_print'
Total allocated 266098
Total retained 803

allocated memory by gem
-----------------------------------
zxcvbn-ruby/lib x 21200073
rubygems x 621303
json-1.8.2 x 348926
2.2.0/lib x 91801
2.2.0 x 18275
other x 160

allocated objects by gem
-----------------------------------
zxcvbn-ruby/lib x 256268
rubygems x 6232
json-1.8.2 x 2348
2.2.0/lib x 1070
2.2.0 x 178
other x 2

retained memory by gem
-----------------------------------
rubygems x 58070
zxcvbn-ruby/lib x 6730
2.2.0 x 4921
json-1.8.2 x 1841
2.2.0/lib x 1360

retained objects by gem
-----------------------------------
rubygems x 650
zxcvbn-ruby/lib x 79
2.2.0 x 42
2.2.0/lib x 17
json-1.8.2 x 17
```

This is probably a good time to bump to v1.0 as well?