### PR TITLE
fix syntax issue

### DIFF
--- a/lib/zxcvbn/entropy.rb
+++ b/lib/zxcvbn/entropy.rb
@@ -129,7 +129,7 @@ module Zxcvbn::Entropy
 
     # estimate the ngpumber of possible patterns w/ token length or less with number of turns or less.
     (2..token_length).each do |i|
-      possible_turns = [turns, i -1].min
+      possible_turns = [turns, i - 1].min
       (1..possible_turns).each do |j|
         possibilities += nCk(i - 1, j - 1) * starting_positions * average_degree ** j
       end


### PR DESCRIPTION
fixes warning with syntax in jruby-9.1.* #19 

The warning was

```
`-' after local variable or literal is interpreted as binary operator
```

For reference:

Related error
https://github.com/colbygk/log4r/issues/52