### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "zxcvbn-ruby"
   gem.require_paths = ["lib"]
   gem.version       = Zxcvbn::VERSION
+  gem.license       = 'MIT'
 
   gem.add_development_dependency 'therubyracer'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.