### PR TITLE
Generate feedback for evaluated passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,41 @@ Example usage:
 $ irb
 >> require 'zxcvbn'
 => true
->> Zxcvbn.test('@lfred2004', ['alfred'])
-=> #<Zxcvbn::Score:0x007fd467803098 @entropy=7.895, @crack_time=0.012, @crack_time_display="instant", @score=0, @match_sequence=[#<Zxcvbn::Match matched_word="alfred", token="@lfred", i=0, j=5, rank=1, pattern="dictionary", dictionary_name="user_inputs", l33t=true, sub={"@"=>"a"}, sub_display"@ -> a", base_entropy0.0, uppercase_entropy0.0, l33t_entropy1, entropy1.0, #<Zxcvbn::Match i=6, j=9, token="2004", pattern="year", entropy=6.894817763307944], @password="@lfred2004", @calc_time=0.003436>
->> Zxcvbn.test('asdfghju7654rewq', ['alfred'])
-=> #<Zxcvbn::Score:0x007fd4689c1168 @entropy=29.782, @crack_time=46159.451, @crack_time_display="14 hours", @score=2, @match_sequence=[#<Zxcvbn::Match pattern="spatial", i=0, j=15, token="asdfghju7654rewq", graph="qwerty", turns=5, shifted_count=0, entropy=29.7820508329166>], password"asdfghju7654rewq", calc_time0.00526
+>> pp Zxcvbn.test('@lfred2004', ['alfred'])
+#<Zxcvbn::Score:0x00007f7f590610c8
+ @calc_time=0.0055760000250302255,
+ @crack_time=0.012,
+ @crack_time_display="instant",
+ @entropy=7.895,
+ @feedback=
+  #<Zxcvbn::Feedback:0x00007f7f59060150
+   @suggestions=
+    ["Add another word or two. Uncommon words are better.",
+     "Predictable substitutions like '@' instead of 'a' don't help very much"],
+   @warning=nil>,
+ @match_sequence=
+  [#<Zxcvbn::Match matched_word="alfred", token="@lfred", i=0, j=5, rank=1, pattern="dictionary", dictionary_name="user_inputs", l33t=true, sub={"@"=>"a"}, sub_display="@ -> a", base_entropy=0.0, uppercase_entropy=0.0, l33t_entropy=1, entropy=1.0>,
+   #<Zxcvbn::Match i=6, j=9, token="2004", pattern="year", entropy=6.894817763307944>],
+ @password="@lfred2004",
+ @score=0>
+=> #<Zxcvbn::Score:0x00007f7f59060150>
+>> pp Zxcvbn.test('asdfghju7654rewq', ['alfred'])
+#<Zxcvbn::Score:0x00007f7f5a9e9248
+ @calc_time=0.007504999986849725,
+ @crack_time=46159.451,
+ @crack_time_display="14 hours",
+ @entropy=29.782,
+ @feedback=
+  #<Zxcvbn::Feedback:0x00007f7f5a9e9130
+   @suggestions=
+    ["Add another word or two. Uncommon words are better.",
+     "Use a longer keyboard pattern with more turns"],
+   @warning="Short keyboard patterns are easy to guess">,
+ @match_sequence=
+  [#<Zxcvbn::Match pattern="spatial", i=0, j=15, token="asdfghju7654rewq", graph="qwerty", turns=5, shifted_count=0, entropy=29.7820508329166>],
+ @password="asdfghju7654rewq",
+ @score=2>
+=> #<Zxcvbn::Score:0x00007f7f5a9e9248>
 ```
 
 ## Testing Multiple Passwords
@@ -34,10 +65,42 @@ $ irb
 => true
 >> tester = Zxcvbn::Tester.new
 => #<Zxcvbn::Tester:0x3fe99d869aa4>
->> tester.test('@lfred2004', ['alfred'])
-=> #<Zxcvbn::Score:0x007fd4689c1168 @entropy=29.782, @crack_time=46159.451, @crack_time_display="14 hours", @score=2, @match_sequence=[#<Zxcvbn::Match pattern="spatial", i=0, j=15, token="asdfghju7654rewq", graph="qwerty", turns=5, shifted_count=0, entropy=29.7820508329166>], password"asdfghju7654rewq", calc_time0.00526
->> tester.test('@lfred2004', ['alfred'])
-=> #<Zxcvbn::Score:0x007fd4689c1168 @entropy=29.782, @crack_time=46159.451, @crack_time_display="14 hours", @score=2, @match_sequence=[#<Zxcvbn::Match pattern="spatial", i=0, j=15, token="asdfghju7654rewq", graph="qwerty", turns=5, shifted_count=0, entropy=29.7820508329166>], password"asdfghju7654rewq", calc_time0.00526
+>> pp tester.test('@lfred2004', ['alfred'])
+#<Zxcvbn::Score:0x00007f7f586fcf50
+ @calc_time=0.00631899997824803,
+ @crack_time=0.012,
+ @crack_time_display="instant",
+ @entropy=7.895,
+ @feedback=
+  #<Zxcvbn::Feedback:0x00007f7f586fcac8
+   @suggestions=
+    ["Add another word or two. Uncommon words are better.",
+     "Predictable substitutions like '@' instead of 'a' don't help very much"],
+   @warning=nil>,
+ @match_sequence=
+  [#<Zxcvbn::Match matched_word="alfred", token="@lfred", i=0, j=5, rank=1, pattern="dictionary", dictionary_name="user_inputs", l33t=true, sub={"@"=>"a"}, sub_display="@ -> a", base_entropy=0.0, uppercase_entropy=0.0, l33t_entropy=1, entropy=1.0>,
+   #<Zxcvbn::Match i=6, j=9, token="2004", pattern="year", entropy=6.894817763307944>],
+ @password="@lfred2004",
+ @score=0>
+=> #<Zxcvbn::Score:0x00007f7f586fcf50>
+>> pp tester.test('@lfred2004', ['alfred'])
+#<Zxcvbn::Score:0x00007f7f56d57438
+ @calc_time=0.001986999996006489,
+ @crack_time=0.012,
+ @crack_time_display="instant",
+ @entropy=7.895,
+ @feedback=
+  #<Zxcvbn::Feedback:0x00007f7f56d56bf0
+   @suggestions=
+    ["Add another word or two. Uncommon words are better.",
+     "Predictable substitutions like '@' instead of 'a' don't help very much"],
+   @warning=nil>,
+ @match_sequence=
+  [#<Zxcvbn::Match matched_word="alfred", token="@lfred", i=0, j=5, rank=1, pattern="dictionary", dictionary_name="user_inputs", l33t=true, sub={"@"=>"a"}, sub_display="@ -> a", base_entropy=0.0, uppercase_entropy=0.0, l33t_entropy=1, entropy=1.0>,
+   #<Zxcvbn::Match i=6, j=9, token="2004", pattern="year", entropy=6.894817763307944>],
+ @password="@lfred2004",
+ @score=0>
+=> #<Zxcvbn::Score:0x00007f7f56d57438>
 ```
 
 **Note**: Storing the entropy of an encrypted or hashed value provides

--- a/lib/zxcvbn/feedback.rb
+++ b/lib/zxcvbn/feedback.rb
@@ -1,0 +1,10 @@
+module Zxcvbn
+  class Feedback
+    attr_accessor :warning, :suggestions
+
+    def initialize(options = {})
+      @warning     = options[:warning]
+      @suggestions = options[:suggestions] || []
+    end
+  end
+end

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -109,9 +109,9 @@ module Zxcvbn
       suggestions = []
       word = match.token
 
-      if word.match?(Zxcvbn::Entropy::START_UPPER)
+      if word =~ Zxcvbn::Entropy::START_UPPER
         suggestions.push "Capitalization doesn't help very much"
-      elsif word.match?(Zxcvbn::Entropy::ALL_UPPER) && word.downcase != word
+      elsif word =~ Zxcvbn::Entropy::ALL_UPPER && word.downcase != word
         suggestions.push(
           'All-uppercase is almost as easy to guess as all-lowercase'
         )

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -81,16 +81,17 @@ module Zxcvbn
           ]
         )
 
-      when 'regex'
-        if match.regex_name == 'recent_year'
-          Feedback.new(
-            warning: 'Recent years are easy to guess',
-            suggestions: [
-              'Avoid recent years',
-              'Avoid years that are associated with you'
-            ]
-          )
-        end
+      # NOTE: This gem doesn't include the `recent_year` regex
+      # when 'regex'
+      #   if match.regex_name == 'recent_year'
+      #     Feedback.new(
+      #       warning: 'Recent years are easy to guess',
+      #       suggestions: [
+      #         'Avoid recent years',
+      #         'Avoid years that are associated with you'
+      #       ]
+      #     )
+      #   end
 
       when 'date'
         Feedback.new(
@@ -112,10 +113,13 @@ module Zxcvbn
                     else
                       'This is a very common password'
                     end
-                  else # elsif match.guesses_log10 <= 4
+                  else
+                    # NOTE: This gem doesn't include the guesses_log10 data,
+                    #       so we just show this for all similar passwords.
+                    # elsif match.guesses_log10 <= 4
                     'This is similar to a commonly used password'
                   end
-                # NOTE: Ruby impl doesn't include the "english_wikipedia" dict
+                # NOTE: This gem doesn't include the "english_wikipedia" dict
                 # elsif match.dictionary_name == 'english_wikipedia'
                 #   'A word by itself is easy to guess' if is_sole_match
                 elsif NAME_DICTIONARIES.include? match.dictionary_name
@@ -137,7 +141,7 @@ module Zxcvbn
         )
       end
 
-      # NOTE: Ruby impl doesn't include reverse dictionary checking
+      # NOTE: This gem doesn't include reverse dictionary checking
       # if match.reversed && match.token.length >= 4
       #   suggestions.push "Reversed words aren't much harder to guess"
       # end

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -60,14 +60,8 @@ module Zxcvbn
         )
 
       when 'repeat'
-        warning = if match.token.length == 1
-                    'Repeats like "aaa" are easy to guess'
-                  else
-                    'Repeats like "abcabcabc" are only slightly harder to guess than "abc"'
-                  end
-
         Feedback.new(
-          warning: warning,
+          warning: 'Repeats like "aaa" are easy to guess',
           suggestions: [
             'Avoid repeated words and characters'
           ]

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -81,18 +81,6 @@ module Zxcvbn
           ]
         )
 
-      # NOTE: This gem doesn't include the `recent_year` regex
-      # when 'regex'
-      #   if match.regex_name == 'recent_year'
-      #     Feedback.new(
-      #       warning: 'Recent years are easy to guess',
-      #       suggestions: [
-      #         'Avoid recent years',
-      #         'Avoid years that are associated with you'
-      #       ]
-      #     )
-      #   end
-
       when 'date'
         Feedback.new(
           warning: 'Dates are often easy to guess',
@@ -114,14 +102,8 @@ module Zxcvbn
                       'This is a very common password'
                     end
                   else
-                    # NOTE: This gem doesn't include the guesses_log10 data,
-                    #       so we just show this for all similar passwords.
-                    # elsif match.guesses_log10 <= 4
                     'This is similar to a commonly used password'
                   end
-                # NOTE: This gem doesn't include the "english_wikipedia" dict
-                # elsif match.dictionary_name == 'english_wikipedia'
-                #   'A word by itself is easy to guess' if is_sole_match
                 elsif NAME_DICTIONARIES.include? match.dictionary_name
                   if is_sole_match
                     'Names and surnames by themselves are easy to guess'
@@ -140,11 +122,6 @@ module Zxcvbn
           'All-uppercase is almost as easy to guess as all-lowercase'
         )
       end
-
-      # NOTE: This gem doesn't include reverse dictionary checking
-      # if match.reversed && match.token.length >= 4
-      #   suggestions.push "Reversed words aren't much harder to guess"
-      # end
 
       if match.l33t
         suggestions.push(

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -1,0 +1,158 @@
+require 'zxcvbn/entropy'
+require 'zxcvbn/feedback'
+
+module Zxcvbn
+  class FeedbackGiver
+    NAME_DICTIONARIES = %w[surnames male_names female_names].freeze
+
+    DEFAULT_FEEDBACK = Feedback.new(
+      suggestions: [
+        'Use a few words, avoid common phrases',
+        'No need for symbols, digits, or uppercase letters'
+      ]
+    ).freeze
+
+    EMPTY_FEEDBACK = Feedback.new.freeze
+
+    def self.get_feedback(score, sequence)
+      # starting feedback
+      return DEFAULT_FEEDBACK if sequence.length.zero?
+
+      # no feedback if score is good or great.
+      return EMPTY_FEEDBACK if score > 2
+
+      # tie feedback to the longest match for longer sequences
+      longest_match = sequence[0]
+      for match in sequence[1..-1]
+        longest_match = match if match.token.length > longest_match.token.length
+      end
+
+      feedback = get_match_feedback(longest_match, sequence.length == 1)
+      extra_feedback = 'Add another word or two. Uncommon words are better.'
+
+      if feedback.nil?
+        feedback = Feedback.new(suggestions: [extra_feedback])
+      else
+        feedback.suggestions.unshift extra_feedback
+      end
+
+      feedback
+    end
+
+    def self.get_match_feedback(match, is_sole_match)
+      case match.pattern
+      when 'dictionary'
+        get_dictionary_match_feedback match, is_sole_match
+
+      when 'spatial'
+        layout = match.graph.upcase
+        warning = if match.turns == 1
+                    'Straight rows of keys are easy to guess'
+                  else
+                    'Short keyboard patterns are easy to guess'
+                  end
+
+        Feedback.new(
+          warning: warning,
+          suggestions: [
+            'Use a longer keyboard pattern with more turns'
+          ]
+        )
+
+      when 'repeat'
+        warning = if match.token.length == 1
+                    'Repeats like "aaa" are easy to guess'
+                  else
+                    'Repeats like "abcabcabc" are only slightly harder to guess than "abc"'
+                  end
+
+        Feedback.new(
+          warning: warning,
+          suggestions: [
+            'Avoid repeated words and characters'
+          ]
+        )
+
+      when 'sequence'
+        Feedback.new(
+          warning: 'Sequences like abc or 6543 are easy to guess',
+          suggestions: [
+            'Avoid sequences'
+          ]
+        )
+
+      when 'regex'
+        if match.regex_name == 'recent_year'
+          Feedback.new(
+            warning: 'Recent years are easy to guess',
+            suggestions: [
+              'Avoid recent years',
+              'Avoid years that are associated with you'
+            ]
+          )
+        end
+
+      when 'date'
+        Feedback.new(
+          warning: 'Dates are often easy to guess',
+          suggestions: [
+            'Avoid dates and years that are associated with you'
+          ]
+        )
+      end
+    end
+
+    def self.get_dictionary_match_feedback(match, is_sole_match)
+      warning = if match.dictionary_name == 'passwords'
+                  if is_sole_match && !match.l33t && !match.reversed
+                    if match.rank <= 10
+                      'This is a top-10 common password'
+                    elsif match.rank <= 100
+                      'This is a top-100 common password'
+                    else
+                      'This is a very common password'
+                    end
+                  else # elsif match.guesses_log10 <= 4
+                    'This is similar to a commonly used password'
+                  end
+                # NOTE: Ruby impl doesn't include the "english_wikipedia" dict
+                # elsif match.dictionary_name == 'english_wikipedia'
+                #   'A word by itself is easy to guess' if is_sole_match
+                elsif NAME_DICTIONARIES.include? match.dictionary_name
+                  if is_sole_match
+                    'Names and surnames by themselves are easy to guess'
+                  else
+                    'Common names and surnames are easy to guess'
+                  end
+                end
+
+      suggestions = []
+      word = match.token
+
+      if word.match?(Zxcvbn::Entropy::START_UPPER)
+        suggestions.push "Capitalization doesn't help very much"
+      elsif word.match?(Zxcvbn::Entropy::ALL_UPPER) && word.downcase != word
+        suggestions.push(
+          'All-uppercase is almost as easy to guess as all-lowercase'
+        )
+      end
+
+      # NOTE: Ruby impl doesn't include reverse dictionary checking
+      # if match.reversed && match.token.length >= 4
+      #   suggestions.push "Reversed words aren't much harder to guess"
+      # end
+
+      if match.l33t
+        suggestions.push(
+          "Predictable substitutions like '@' instead of 'a' \
+don't help very much"
+        )
+      end
+
+      Feedback.new(
+        warning: warning,
+        suggestions: suggestions
+      )
+    end
+  end
+end

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -1,4 +1,5 @@
 require 'benchmark'
+require 'zxcvbn/feedback_giver'
 require 'zxcvbn/omnimatch'
 require 'zxcvbn/scorer'
 
@@ -17,6 +18,7 @@ module Zxcvbn
         result = @scorer.minimum_entropy_match_sequence(password, matches)
       end
       result.calc_time = calc_time
+      result.feedback = FeedbackGiver.get_feedback(result.score, result.match_sequence)
       result
     end
   end

--- a/lib/zxcvbn/score.rb
+++ b/lib/zxcvbn/score.rb
@@ -1,7 +1,7 @@
 module Zxcvbn
   class Score
     attr_accessor :entropy, :crack_time, :crack_time_display, :score, :pattern,
-                  :match_sequence, :password, :calc_time
+                  :match_sequence, :password, :calc_time, :feedback
 
     def initialize(options = {})
       @entropy            = options[:entropy]

--- a/spec/feedback_giver_spec.rb
+++ b/spec/feedback_giver_spec.rb
@@ -25,9 +25,19 @@ describe Zxcvbn::FeedbackGiver do
       )
     end
 
+    it "gives general feedback when a password is poor but doesn't match any heuristics" do
+      feedback = tester.test(':005:0').feedback
+
+      expect(feedback).to be_a Zxcvbn::Feedback
+      expect(feedback.warning).to be_nil
+      expect(feedback.suggestions).to contain_exactly(
+        'Add another word or two. Uncommon words are better.'
+      )
+    end
+
     describe 'gives specific feedback' do
       describe 'for dictionary passwords' do
-        it 'when a password is extremely common' do
+        it 'that are extremely common' do
           feedback = tester.test('password').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -37,7 +47,7 @@ describe Zxcvbn::FeedbackGiver do
           )
         end
 
-        it 'when a password is very, very common' do
+        it 'that are very, very common' do
           feedback = tester.test('letmein').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -47,7 +57,7 @@ describe Zxcvbn::FeedbackGiver do
           )
         end
 
-        it 'when a password is very common' do
+        it 'that are very common' do
           feedback = tester.test('playstation').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -57,7 +67,7 @@ describe Zxcvbn::FeedbackGiver do
           )
         end
 
-        it 'when a password is common and you tried to use l33tsp33k' do
+        it 'that are common and you tried to use l33tsp33k' do
           feedback = tester.test('pl4yst4ti0n').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -66,12 +76,11 @@ describe Zxcvbn::FeedbackGiver do
           )
           expect(feedback.suggestions).to contain_exactly(
             'Add another word or two. Uncommon words are better.',
-            "Predictable substitutions like '@' instead of 'a' \
-don't help very much"
+            "Predictable substitutions like '@' instead of 'a' don't help very much"
           )
         end
 
-        it 'when a password is common and you capitalised the start' do
+        it 'that are common and you capitalised the start' do
           feedback = tester.test('Password').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -84,7 +93,7 @@ don't help very much"
           )
         end
 
-        it 'when a password is common and you capitalised the whole thing' do
+        it 'that are common and you capitalised the whole thing' do
           feedback = tester.test('PASSWORD').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -97,7 +106,7 @@ don't help very much"
           )
         end
 
-        it 'when a password contains a common first name or last name' do
+        it 'that contain a common first name or last name' do
           feedback = tester.test('jessica').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -119,7 +128,7 @@ don't help very much"
           )
         end
 
-        it 'when a password contains a common name and surname' do
+        it 'that contain a common name and surname' do
           feedback = tester.test('jessica smith').feedback
 
           expect(feedback).to be_a Zxcvbn::Feedback
@@ -130,6 +139,73 @@ don't help very much"
             'Add another word or two. Uncommon words are better.'
           )
         end
+      end
+
+      describe 'for spatial passwords' do
+        it 'that contain a straight keyboard row' do
+          feedback = tester.test('1qaz').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'Straight rows of keys are easy to guess'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.',
+            'Use a longer keyboard pattern with more turns'
+          )
+        end
+
+        it 'that contain a keyboard pattern with one turn' do
+          feedback = tester.test('zaqwer').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'Short keyboard patterns are easy to guess'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.',
+            'Use a longer keyboard pattern with more turns'
+          )
+        end
+      end
+
+      it 'for passwords with repeated characters' do
+        feedback = tester.test('zzz').feedback
+
+        expect(feedback).to be_a Zxcvbn::Feedback
+        expect(feedback.warning).to eql(
+          'Repeats like "aaa" are easy to guess'
+        )
+        expect(feedback.suggestions).to contain_exactly(
+          'Add another word or two. Uncommon words are better.',
+          'Avoid repeated words and characters'
+        )
+      end
+
+      it 'for passwords with sequential characters' do
+        feedback = tester.test('pqrpqrpqr').feedback
+
+        expect(feedback).to be_a Zxcvbn::Feedback
+        expect(feedback.warning).to eql(
+          'Sequences like abc or 6543 are easy to guess'
+        )
+        expect(feedback.suggestions).to contain_exactly(
+          'Add another word or two. Uncommon words are better.',
+          'Avoid sequences'
+        )
+      end
+
+      it 'for passwords containing dates' do
+        feedback = tester.test('testing02\12\1997').feedback
+
+        expect(feedback).to be_a Zxcvbn::Feedback
+        expect(feedback.warning).to eql(
+          'Dates are often easy to guess'
+        )
+        expect(feedback.suggestions).to contain_exactly(
+          'Add another word or two. Uncommon words are better.',
+          'Avoid dates and years that are associated with you'
+        )
       end
     end
   end

--- a/spec/feedback_giver_spec.rb
+++ b/spec/feedback_giver_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+describe Zxcvbn::FeedbackGiver do
+  # NOTE: We go in via the tester because the `FeedbackGiver` relies on both
+  #       Omnimatch and the Scorer, which are troublesome to wire up for tests
+  let(:tester) { Zxcvbn::Tester.new }
+
+  describe '.get_feedback' do
+    it "gives empty feedback when a password's score is good" do
+      feedback = tester.test('5815A30BE798').feedback
+
+      expect(feedback).to be_a Zxcvbn::Feedback
+      expect(feedback.warning).to be_nil
+      expect(feedback.suggestions).to be_empty
+    end
+
+    it 'gives general feedback when a password is empty' do
+      feedback = tester.test('').feedback
+
+      expect(feedback).to be_a Zxcvbn::Feedback
+      expect(feedback.warning).to be_nil
+      expect(feedback.suggestions).to contain_exactly(
+        'Use a few words, avoid common phrases',
+        'No need for symbols, digits, or uppercase letters'
+      )
+    end
+
+    describe 'gives specific feedback' do
+      describe 'for dictionary passwords' do
+        it 'when a password is extremely common' do
+          feedback = tester.test('password').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql('This is a top-10 common password')
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.'
+          )
+        end
+
+        it 'when a password is very, very common' do
+          feedback = tester.test('letmein').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql('This is a top-100 common password')
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.'
+          )
+        end
+
+        it 'when a password is very common' do
+          feedback = tester.test('playstation').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql('This is a very common password')
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.'
+          )
+        end
+
+        it 'when a password is common and you tried to use l33tsp33k' do
+          feedback = tester.test('pl4yst4ti0n').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'This is similar to a commonly used password'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.',
+            "Predictable substitutions like '@' instead of 'a' \
+don't help very much"
+          )
+        end
+
+        it 'when a password is common and you capitalised the start' do
+          feedback = tester.test('Password').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'This is a top-10 common password'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.',
+            "Capitalization doesn't help very much"
+          )
+        end
+
+        it 'when a password is common and you capitalised the whole thing' do
+          feedback = tester.test('PASSWORD').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'This is a top-10 common password'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.',
+            'All-uppercase is almost as easy to guess as all-lowercase'
+          )
+        end
+
+        it 'when a password contains a common first name or last name' do
+          feedback = tester.test('jessica').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'Names and surnames by themselves are easy to guess'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.'
+          )
+
+          feedback = tester.test('smith').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'Names and surnames by themselves are easy to guess'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.'
+          )
+        end
+
+        it 'when a password contains a common name and surname' do
+          feedback = tester.test('jessica smith').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'Common names and surnames are easy to guess'
+          )
+          expect(feedback.suggestions).to contain_exactly(
+            'Add another word or two. Uncommon words are better.'
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -17,9 +17,9 @@ describe Zxcvbn::Tester do
       expect(ruby_result.pattern).to eq js_result['pattern']
       expect(ruby_result.match_sequence.count).to eq js_result['match_sequence'].count
 
-      # NOTE: feedback doesn't exist in these old versions of the library,
-      #       so instead we just check that it put `Feedback` in there.
-      #       Real tests for its values go in `feedback_giver_spec.rb`
+      # NOTE: feedback didn't exist in the version of the JS library this gem
+      #       is based on, so instead we just check that it put `Feedback` in
+      #       there. Real tests for its values go in `feedback_giver_spec.rb`.
       expect(ruby_result.feedback).to be_a Zxcvbn::Feedback
     end
   end

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -16,6 +16,11 @@ describe Zxcvbn::Tester do
       expect(ruby_result.score).to eq js_result['score']
       expect(ruby_result.pattern).to eq js_result['pattern']
       expect(ruby_result.match_sequence.count).to eq js_result['match_sequence'].count
+
+      # NOTE: feedback doesn't exist in these old versions of the library,
+      #       so instead we just check that it put `Feedback` in there.
+      #       Real tests for its values go in `feedback_giver_spec.rb`
+      expect(ruby_result.feedback).to be_a Zxcvbn::Feedback
     end
   end
 


### PR DESCRIPTION
This backports a majority of [the feedback mechanism](https://github.com/dropbox/zxcvbn/blob/67c4ece9efc40c9d0a1d7d995b2b22a91be500c2/src/feedback.coffee) added to more recent versions of zxcvbn.js to the Gem.

The Gem is based on an older version of the JS library, so some of the features it gives feedback based on are missing;
- Multi-character repeat matches
  - Instead, only single-character repetition is given feedback
- The “recent year” regex match
  - Instead, feedback for this is not included
- Low guess-count (`guesses_log10`) passwords similar to a dictionary password
  - Instead, all similar passwords are reported
- The `english_wikipedia` dictionary
  - Instead, feedback for this is not included
- Checks for reversed dictionary words
  - Instead, feedback for this is not included

Despite that, this adds a valuable mechanism for guiding users to build more useful passwords, in a way the Gem previously didn’t support.

I’ve done my best to maintain the conventions set by the rest of the Gem’s code structure and module style, so I hope I’ve done it justice! I’ve also provided a full spec for the new `FeedbackGiver` class, and added a basic check for the `Tester` class to ensure it’s generating feedback as part of results.