### PR TITLE
Only build against supported versions of ruby. 2.3 +

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - '1.9'
-  - '2.0'
-  - '2.1'
-  - '2.2'
-  - '2.3.0'
+  - '2.3'
+  - '2.4'
+  - '2.5'
+  - '2.6'
   - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
   fast_finish: true
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Removed
+- This gem will no longer run on Ruby versions < 2.3

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.version       = Zxcvbn::VERSION
   gem.license       = 'MIT'
 
+  gem.required_ruby_version = '~> 2.3'
+
   gem.add_development_dependency 'therubyracer'
   gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Build was failing as some older versions of ruby seemed to have issues.

This PR is to update the build to test against 2.3 2.4 2.5 2.6 ruby versions.