### PR TITLE
Handle invalid user dictionaries more robustly 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+ - Invalid user dictionaries are handled more robustly [[#28][28]
+
+[28]: https://github.com/envato/zxcvbn-ruby/pull/28
+
 ## [1.0.0] - 2019-05-14
 ### Added
 Adds more ported password checking features to bring this gem more up to date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
- - Invalid user dictionaries are handled more robustly [[#28][28]
+ - Invalid user dictionaries are handled more robustly [[#28]][28]
 
 [28]: https://github.com/envato/zxcvbn-ruby/pull/28
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gemspec
 group :development do
   gem 'guard'
   gem 'guard-bundler', require: false
+  gem 'guard-rspec', require: false
   gem 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem 'guard'
   gem 'rake'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gemspec
 
 group :development do
   gem 'guard'
+  gem 'guard-bundler', require: false
   gem 'rake'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,16 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"

--- a/Guardfile
+++ b/Guardfile
@@ -26,3 +26,57 @@ guard :bundler do
   # Assume files are symlinked from somewhere
   files.each { |file| watch(helper.real_path(file)) }
 end
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.call("routing/#{m[1]}_routing"),
+      rspec.spec.call("controllers/#{m[1]}_controller"),
+      rspec.spec.call("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  end
+end

--- a/Guardfile
+++ b/Guardfile
@@ -14,3 +14,15 @@
 #  $ ln -s config/Guardfile .
 #
 # and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+guard :bundler do
+  require 'guard/bundler'
+  require 'guard/bundler/verify'
+  helper = Guard::Bundler::Verify.new
+
+  files = ['Gemfile']
+  files += Dir['*.gemspec'] if files.any? { |f| helper.uses_gemspec?(f) }
+
+  # Assume files are symlinked from somewhere
+  files.each { |file| watch(helper.real_path(file)) }
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,20 +1,3 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-## Uncomment and set this to only include directories you want to watch
-# directories %w(app lib config test spec features) \
-#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
-
-## Note: if you are using the `directories` clause above and you are not
-## watching the project directory ('.'), then you will want to move
-## the Guardfile to a watched dir and symlink it back, e.g.
-#
-#  $ mkdir config
-#  $ mv Guardfile config/
-#  $ ln -s config/Guardfile .
-#
-# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
-
 guard :bundler do
   require 'guard/bundler'
   require 'guard/bundler/verify'
@@ -27,20 +10,9 @@ guard :bundler do
   files.each { |file| watch(helper.real_path(file)) }
 end
 
-# Note: The cmd option is now required due to the increasing number of ways
-#       rspec may be run, below are examples of the most common uses.
-#  * bundler: 'bundle exec rspec'
-#  * bundler binstubs: 'bin/rspec'
-#  * spring: 'bin/rspec' (This will use spring if running and you have
-#                          installed the spring binstubs per the docs)
-#  * zeus: 'zeus rspec' (requires the server to be started separately)
-#  * 'just' rspec: 'rspec'
-
 guard :rspec, cmd: "bundle exec rspec" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
-
-  # Feel free to open issues for suggestions and improvements
 
   # RSpec files
   rspec = dsl.rspec
@@ -51,32 +23,4 @@ guard :rspec, cmd: "bundle exec rspec" do
   # Ruby files
   ruby = dsl.ruby
   dsl.watch_spec_files_for(ruby.lib_files)
-
-  # Rails files
-  rails = dsl.rails(view_extensions: %w(erb haml slim))
-  dsl.watch_spec_files_for(rails.app_files)
-  dsl.watch_spec_files_for(rails.views)
-
-  watch(rails.controllers) do |m|
-    [
-      rspec.spec.call("routing/#{m[1]}_routing"),
-      rspec.spec.call("controllers/#{m[1]}_controller"),
-      rspec.spec.call("acceptance/#{m[1]}")
-    ]
-  end
-
-  # Rails config changes
-  watch(rails.spec_helper)     { rspec.spec_dir }
-  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
-  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
-
-  # Capybara features specs
-  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
-
-  # Turnip features and steps
-  watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-  end
 end

--- a/lib/zxcvbn/matchers/l33t.rb
+++ b/lib/zxcvbn/matchers/l33t.rb
@@ -31,8 +31,8 @@ module Zxcvbn
               token = password[match.i..match.j]
               next if token.downcase == match.matched_word.downcase
               match_substitutions = {}
-              substitution.each do |substitution, letter|
-                match_substitutions[substitution] = letter if token.include?(substitution)
+              substitution.each do |s, letter|
+                match_substitutions[s] = letter if token.include?(s)
               end
               match.l33t = true
               match.token = password[match.i..match.j]

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -25,7 +25,7 @@ module Zxcvbn
     end
 
     def add_word_lists(lists)
-      lists.each_pair {|name, words| @data.add_word_list(name, words)}
+      lists.each_pair { |name, words| @data.add_word_list(name, sanitize(words)) }
     end
 
     def inspect

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -1,5 +1,7 @@
-require 'zxcvbn/data'
-require 'zxcvbn/password_strength'
+# frozen_string_literal: true
+
+require "zxcvbn/data"
+require "zxcvbn/password_strength"
 
 module Zxcvbn
   # Allows you to test the strength of multiple passwords without reading and
@@ -29,7 +31,7 @@ module Zxcvbn
     end
 
     def inspect
-      "#<#{self.class}:0x#{self.__id__.to_s(16)}>"
+      "#<#{self.class}:0x#{__id__.to_s(16)}>"
     end
 
     private

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -21,7 +21,7 @@ module Zxcvbn
     end
 
     def test(password, user_inputs = [])
-      PasswordStrength.new(@data).test(password, user_inputs)
+      PasswordStrength.new(@data).test(password, sanitize(user_inputs))
     end
 
     def add_word_lists(lists)
@@ -30,6 +30,12 @@ module Zxcvbn
 
     def inspect
       "#<#{self.class}:0x#{self.__id__.to_s(16)}>"
+    end
+
+    private
+
+    def sanitize(user_inputs)
+      user_inputs.select { |i| i.respond_to?(:downcase) }
     end
   end
 end

--- a/spec/matchers/dictionary_spec.rb
+++ b/spec/matchers/dictionary_spec.rb
@@ -1,19 +1,30 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe Zxcvbn::Matchers::Dictionary do
-  let(:matcher) { described_class.new('english', dictionary) }
-  let(:dictionary) { Zxcvbn::Data.new.ranked_dictionaries['english'] }
+  subject(:matcher) { described_class.new("Test dictionary", dictionary) }
 
-  it 'finds all the matches' do
-    matches = matcher.matches('whatisinit')
-    expect(matches.count).to eq(14)
-    expected_matches = ['wha', 'what', 'ha', 'hat', 'a', 'at', 'tis', 'i', 'is',
-                       'sin', 'i', 'in', 'i', 'it']
-    expect(matches.map(&:matched_word)).to eq(expected_matches)
-  end
+  describe "#matches" do
+    let(:matches) { matcher.matches(password) }
+    let(:matched_words) { matches.map(&:matched_word) }
 
-  it 'matches uppercase' do
-    matcher = described_class.new('user_inputs', Zxcvbn::DictionaryRanker.rank_dictionary(['test','AB10CD']))
-    expect(matcher.matches('AB10CD')).not_to be_empty
+    context "Given a dictionary of English words" do
+      let(:dictionary) { Zxcvbn::Data.new.ranked_dictionaries["english"] }
+      let(:password) { "whatisinit" }
+
+      it "finds all the matches" do
+        expect(matched_words).to match_array %w[wha what ha hat a at tis i is sin i in i it]
+      end
+    end
+
+    context "Given a custom dictionary" do
+      let(:dictionary) { Zxcvbn::DictionaryRanker.rank_dictionary(%w[test AB10CD]) }
+      let(:password) { "AB10CD" }
+
+      it "matches uppercase passwords with normalised dictionary entries" do
+        expect(matched_words).to match_array(%w[ab10cd])
+      end
+    end
   end
 end

--- a/spec/matchers/l33t_spec.rb
+++ b/spec/matchers/l33t_spec.rb
@@ -51,12 +51,14 @@ describe Zxcvbn::Matchers::L33t do
   end
 
   describe '#matches' do
-    let(:matches) { matcher.matches('p@ssword') }
-    # it doesn't match on 'password' because that's not in the english
-    # dictionary/frequency list
+    subject(:matches) { matcher.matches('p@ssword') }
+
+    it "doesn't find 'password' because it's not in english.txt" do
+      expect(matches.map(&:matched_word)).not_to include "password"
+    end
 
     it 'finds the correct matches' do
-      expect(matches.map(&:matched_word)).to eq([
+      expect(matches.map(&:matched_word)).to match_array([
         'pas',
         'a',
         'as',
@@ -65,7 +67,7 @@ describe Zxcvbn::Matchers::L33t do
     end
 
     it 'sets the token correctly on those matches' do
-      expect(matches.map(&:token)).to eq([
+      expect(matches.map(&:token)).to match_array([
         'p@s',
         '@',
         '@s',
@@ -74,7 +76,7 @@ describe Zxcvbn::Matchers::L33t do
     end
 
     it 'sets the substituions used' do
-      expect(matches.map(&:sub)).to eq([
+      expect(matches.map(&:sub)).to match_array([
         {'@' => 'a'},
         {'@' => 'a'},
         {'@' => 'a'},

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -50,7 +50,7 @@ describe Zxcvbn::Tester do
 
   context 'nil password' do
     specify do
-      expect { tester.test(nil) }.to_not raise_error
+      expect(tester.test(nil)).to have_attributes(entropy: 0, score: 0, crack_time: 0)
     end
   end
 end

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe Zxcvbn::Tester do
   let(:tester) { Zxcvbn::Tester.new }
@@ -10,13 +12,13 @@ describe Zxcvbn::Tester do
       js_result = js_zxcvbn(password)
 
       expect(ruby_result.calc_time).not_to be_nil
-      expect(ruby_result.password).to eq js_result['password']
-      expect(ruby_result.entropy).to eq js_result['entropy']
-      expect(ruby_result.crack_time).to eq js_result['crack_time']
-      expect(ruby_result.crack_time_display).to eq js_result['crack_time_display']
-      expect(ruby_result.score).to eq js_result['score']
-      expect(ruby_result.pattern).to eq js_result['pattern']
-      expect(ruby_result.match_sequence.count).to eq js_result['match_sequence'].count
+      expect(ruby_result.password).to eq js_result["password"]
+      expect(ruby_result.entropy).to eq js_result["entropy"]
+      expect(ruby_result.crack_time).to eq js_result["crack_time"]
+      expect(ruby_result.crack_time_display).to eq js_result["crack_time_display"]
+      expect(ruby_result.score).to eq js_result["score"]
+      expect(ruby_result.pattern).to eq js_result["pattern"]
+      expect(ruby_result.match_sequence.count).to eq js_result["match_sequence"].count
 
       # NOTE: feedback didn't exist in the version of the JS library this gem
       #       is based on, so instead we just check that it put `Feedback` in
@@ -25,15 +27,15 @@ describe Zxcvbn::Tester do
     end
   end
 
-  context 'with a custom user dictionary' do
-    it 'scores them against the user dictionary' do
-      result = tester.test('themeforest', ['themeforest'])
+  context "with a custom user dictionary" do
+    it "scores them against the user dictionary" do
+      result = tester.test("themeforest", ["themeforest"])
       expect(result.entropy).to eq 0
       expect(result.score).to eq 0
     end
 
-    it 'matches l33t substitutions on this dictionary' do
-      result = tester.test('th3m3for3st', ['themeforest'])
+    it "matches l33t substitutions on this dictionary" do
+      result = tester.test("th3m3for3st", ["themeforest"])
       expect(result.entropy).to eq 1
       expect(result.score).to eq 0
     end
@@ -71,11 +73,11 @@ describe Zxcvbn::Tester do
     end
   end
 
-  context 'with a custom global dictionary' do
-    before { tester.add_word_lists('envato' => ['envato']) }
+  context "with a custom global dictionary" do
+    before { tester.add_word_lists("envato" => ["envato"]) }
 
-    it 'scores them against the dictionary' do
-      result = tester.test('envato')
+    it "scores them against the dictionary" do
+      result = tester.test("envato")
       expect(result.entropy).to eq 0
       expect(result.score).to eq 0
     end
@@ -89,7 +91,7 @@ describe Zxcvbn::Tester do
     end
   end
 
-  context 'nil password' do
+  context "nil password" do
     specify do
       expect(tester.test(nil)).to have_attributes(entropy: 0, score: 0, crack_time: 0)
     end

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'spec_helper'
 
 describe Zxcvbn::Tester do
@@ -38,8 +39,32 @@ describe Zxcvbn::Tester do
     end
   end
 
+  context "with Unicode entries in the password" do
+    it "validates the password" do
+      result = tester.test("✅🐴🔋staple", %w[Theme Forest themeforest])
+      expect(result.entropy).to be_positive
+      expect(result.score).to be_positive
+    end
+  end
+
+  context "with Unicode entries in the dictionary" do
+    it "validates the password" do
+      result = tester.test("correct horse battery staple", %w[✅ 🐴 🔋])
+      expect(result.entropy).to be_positive
+      expect(result.score).to be_positive
+    end
+  end
+
+  context "with Unicode entries in the password and the dictionary" do
+    it "validates the password" do
+      result = tester.test("✅🐴🔋staple", %w[✅ 🐴 🔋])
+      expect(result.entropy).to be_positive
+      expect(result.score).to be_zero
+    end
+  end
+
   context "with invalid entries in the dictionary" do
-    it "ignores those entris" do
+    it "ignores those entries" do
       result = tester.test("themeforest", [nil, 1, "themeforest"])
       expect(result.entropy).to eq 0
       expect(result.score).to eq 0

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -38,9 +38,9 @@ describe Zxcvbn::Tester do
     end
   end
 
-  context 'with an invalid entry in the dictionary' do
-    it 'ignores that entry' do
-      result = tester.test('themeforest', [nil, 1, 'themeforest'])
+  context "with invalid entries in the dictionary" do
+    it "ignores those entris" do
+      result = tester.test("themeforest", [nil, 1, "themeforest"])
       expect(result.entropy).to eq 0
       expect(result.score).to eq 0
     end
@@ -53,6 +53,14 @@ describe Zxcvbn::Tester do
       result = tester.test('envato')
       expect(result.entropy).to eq 0
       expect(result.score).to eq 0
+    end
+
+    context "with invalid entries in a custom dictionary" do
+      before { tester.add_word_lists("themeforest" => [nil, 1, "themeforest"]) }
+
+      it "ignores those entries" do
+        expect(tester.test("themeforest")).to have_attributes(entropy: 0, score: 0, crack_time: 0)
+      end
     end
   end
 

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -38,6 +38,14 @@ describe Zxcvbn::Tester do
     end
   end
 
+  context 'with an invalid entry in the dictionary' do
+    it 'ignores that entry' do
+      result = tester.test('themeforest', [nil, 1, 'themeforest'])
+      expect(result.entropy).to eq 0
+      expect(result.score).to eq 0
+    end
+  end
+
   context 'with a custom global dictionary' do
     before { tester.add_word_lists('envato' => ['envato']) }
 


### PR DESCRIPTION
#### Context

We've had some application errors (`NoMethodError: undefined method 'downcase' for nil:NilClass`), which happens in the l33t matcher: https://github.com/envato/zxcvbn-ruby/blob/07ef78b72bcbd309baf2c843b739b38ac14bd696/lib/zxcvbn/matching/l33t.rb#L32

Due to the way we conceal personally identifiable information, we cannot see the input values that are triggering the problem.

This PR is the result of me trying (and failing) to reproduce the error in this gem.

#### Change

 - Improved a bunch of tests
 - Added [Guard](https://guardgem.org/) gem for faster feedback
 - Handle invalid user dictionaries more robustly (this is as close as I could get to reproducing the error)