### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - '2.3'
   - '2.4'
   - '2.5'
   - '2.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - '2.4'
   - '2.5'
   - '2.6'
   - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - '2.4'
   - '2.5'
   - '2.6'
+  - '2.7'
   - ruby-head
 matrix:
   allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Support for Ruby 2.7 [[#29]]
+ - Gem metadata [[#29]]
+
+### Removed
+ - Support for Ruby 2.3 [[#29]]
+ - Support for Ruby 2.4 [[#29]]
+
+[29]: https://github.com/envato/zxcvbn-ruby/pull/29
+
 
 ## [1.0.0] - 2019-05-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
- - Support for Ruby 2.7 [[#29]]
- - Gem metadata [[#29]]
+ - Support for Ruby 2.7 ([#29])
+ - Gem metadata ([#29])
 
 ### Removed
- - Support for Ruby 2.3 [[#29]]
- - Support for Ruby 2.4 [[#29]]
-
-[29]: https://github.com/envato/zxcvbn-ruby/pull/29
-
+ - Support for Ruby 2.3 ([#29])
+ - Support for Ruby 2.4 ([#29])
 
 ### Fixed
- - Invalid user dictionaries are handled more robustly [[#28]][28]
+ - Invalid user dictionaries are handled more robustly ([#28])
 
+[Unreleased]: https://github.com/envato/zxcvbn-ruby/compare/v1.0.0...HEAD
 [28]: https://github.com/envato/zxcvbn-ruby/pull/28
+[29]: https://github.com/envato/zxcvbn-ruby/pull/29
 
 ## [1.0.0] - 2019-05-14
 ### Added
-Adds more ported password checking features to bring this gem more up to date.
-spatial - Keyboard patterns
-repeat - Repeated characters
-sequence - easily guessable sequences
-date - date associations
-[PR for further details](https://github.com/envato/zxcvbn-ruby/pull/22)
+ - License info in the gemspec ([#21])
+ - More ported password checking features to bring this gem more up to date. ([#22])
+    - spatial - Keyboard patterns
+    - repeat - Repeated characters
+    - sequence - easily guessable sequences
+    - date - date associations
 
 ### Removed
-- This gem will no longer run on Ruby versions < 2.3
+- This gem will no longer run on Ruby versions < 2.3 ([#25])
+
+[1.0.0]: https://github.com/envato/zxcvbn-ruby/compare/v0.1.2...v1.0.0
+[#21]: https://github.com/envato/zxcvbn-ruby/pull/21
+[#22]: https://github.com/envato/zxcvbn-ruby/pull/22
+[#25]: https://github.com/envato/zxcvbn-ruby/pull/25
+

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -20,4 +20,12 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'therubyracer'
   gem.add_development_dependency 'rspec'
+
+  gem.metadata = {
+    "bug_tracker_uri" => "https://github.com/envato/zxcvbn-ruby/issues",
+    "changelog_uri" => "https://github.com/envato/zxcvbn-ruby/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/envato/zxcvbn-ruby/blob/master/README.md",
+    "homepage_uri" => "https://github.com/envato/zxcvbn-ruby",
+    "source_code_uri" => "https://github.com/envato/zxcvbn-ruby"
+  }
 end

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Zxcvbn::VERSION
   gem.license       = 'MIT'
 
-  gem.required_ruby_version = '~> 2.3'
+  gem.required_ruby_version = '~> 2.5'
 
   gem.add_development_dependency 'therubyracer'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
### Context

Preparing to release #28 in v1.1, I noted we're not testing against Ruby 2.7 in CI.

### Change

 - Add support for Ruby 2.7
 - Remove support for ruby 2.3 & 2.4
 - Keep gemspec up-to-date