### PR TITLE
Use mini_racer instead of therubyracer

### DIFF
--- a/spec/support/js_helpers.rb
+++ b/spec/support/js_helpers.rb
@@ -1,4 +1,4 @@
-require 'v8'
+require 'mini_racer'
 require 'json'
 
 module JsHelpers
@@ -6,9 +6,8 @@ module JsHelpers
     JS_SOURCE_PATH = Pathname(File.expand_path('../js_source/', __FILE__))
 
     def initialize
-      @ctx = V8::Context.new do |ctx|
-        ctx.eval(JS_SOURCE_PATH.join('compiled.js').read)
-      end
+      @ctx = MiniRacer::Context.new
+      @ctx.eval(JS_SOURCE_PATH.join('compiled.js').read)
     end
 
     def eval(string)

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '~> 2.5'
 
-  gem.add_development_dependency 'therubyracer'
+  gem.add_development_dependency 'mini_racer'
   gem.add_development_dependency 'rspec'
 
   gem.metadata = {


### PR DESCRIPTION
I had trouble installing the development dependencies on my local machine and was pointed towards using `mini_racer` over `therubyracer` in this comment: https://github.com/rubyjs/libv8/issues/282#issuecomment-661862300

It seems like therubyracer was previously only used for the tests, so in order to verify that this works I ran `bundle exec rspec` and verified that all tests succeeded.

From the mini_racer docs:

> MiniRacer provides a minimal two way bridge between the V8 JavaScript engine and Ruby.
>
> It was created as an alternative to the excellent therubyracer. Unlike therubyracer, mini_racer only implements a minimal bridge. This reduces the surface area making upgrading v8 much simpler and exhaustive testing simpler.