### PR TITLE
Create zxcvbn-ruby.rb

### DIFF
--- a/lib/zxcvbn-ruby.rb
+++ b/lib/zxcvbn-ruby.rb
@@ -1,0 +1,1 @@
+require_relative "zxcvbn"


### PR DESCRIPTION
To go from

```
gem "zxcvbn-ruby", require: "zxcvbn"
```

To:

```
gem "zxcvbn-ruby"
```