### PR TITLE
Address deprecation warnings in Ruby 3.4

### DIFF
--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -77,7 +77,7 @@ module Zxcvbn
           }
           for i in 0...token.length
             key = PATTERN_CHAR_TO_SYM[pattern[i]]
-            candidate[key] = (candidate[key] || String.new)
+            candidate[key] = +(candidate[key] || String.new)
             candidate[key] << token[i]
           end
           candidate.each do |component, value|

--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -76,7 +76,9 @@ module Zxcvbn
             :day => ''
           }
           for i in 0...token.length
-            candidate[PATTERN_CHAR_TO_SYM[pattern[i]]] << token[i]
+            key = PATTERN_CHAR_TO_SYM[pattern[i]]
+            candidate[key] = (candidate[key] || String.new)
+            candidate[key] << token[i]
           end
           candidate.each do |component, value|
             candidate[component] = value.to_i

--- a/spec/scoring/entropy_spec.rb
+++ b/spec/scoring/entropy_spec.rb
@@ -36,7 +36,7 @@ describe Zxcvbn::Entropy do
       let(:token) { '23456' }
 
       it 'returns the correct value' do
-        expect(entropy.sequence_entropy(match)).to eq 5.643856189774725
+        expect(entropy.sequence_entropy(match)).to be_within(1e-12).of(5.643856189774725)
       end
     end
 
@@ -69,7 +69,7 @@ describe Zxcvbn::Entropy do
   describe '#digits_entropy' do
     it 'returns the correct value' do
       match = Zxcvbn::Match.new(:token => '12345678')
-      expect(entropy.digits_entropy(match)).to eq 26.5754247590989
+      expect(entropy.digits_entropy(match)).to be_within(1e-12).of(26.5754247590989)
     end
   end
 
@@ -183,7 +183,7 @@ describe Zxcvbn::Entropy do
       it 'should return the correct entropy' do
         match.graph = 'keypad'
 
-        expect(entropy.spatial_entropy(match)).to eql 9.05528243550119
+        expect(entropy.spatial_entropy(match)).to be_within(1e-12).of(9.05528243550119)
       end
     end
 
@@ -191,7 +191,7 @@ describe Zxcvbn::Entropy do
       it 'should return the correct entropy' do
         match.turns = 5
 
-        expect(entropy.spatial_entropy(match)).to eql 21.761397858718993
+        expect(entropy.spatial_entropy(match)).to be_within(1e-12).of(21.761397858718993)
       end
     end
 
@@ -199,7 +199,7 @@ describe Zxcvbn::Entropy do
       it 'should return the correct entropy' do
         match.shiffted_count = 5
 
-        expect(entropy.spatial_entropy(match)).to eql 9.05528243550119
+        expect(entropy.spatial_entropy(match)).to be_within(1e-12).of(9.05528243550119)
       end
     end
 
@@ -208,7 +208,7 @@ describe Zxcvbn::Entropy do
         match.shiffted_count = 5
         match.turns          = 5
 
-        expect(entropy.spatial_entropy(match)).to eql 21.761397858718993
+        expect(entropy.spatial_entropy(match)).to be_within(1e-12).of(21.761397858718993)
       end
     end
   end


### PR DESCRIPTION
This addresses the `warning: literal string will be frozen in the future` deprecation warning and gets tests passing under Ruby 3.4.