### PR TITLE
Add Ruby 4.0 to the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/lib/zxcvbn/dictionary_ranker.rb
+++ b/lib/zxcvbn/dictionary_ranker.rb
@@ -9,10 +9,9 @@ module Zxcvbn
     end
 
     def self.rank_dictionary(words)
-      words.each_with_index
-           .with_object({}) do |(word, i), dictionary|
-        dictionary[word.downcase] = i + 1
-      end
+      words
+        .each_with_index
+        .with_object({}) { |(word, i), dictionary| dictionary[word.downcase] = i + 1 }
     end
   end
 end


### PR DESCRIPTION
Ruby 4.0 has [been released](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/)! Let's add it to the CI build matrix for confidence in compatibility.