### PR TITLE
Implement Trie data structure for dictionary matching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,13 @@
 inherit_from: .rubocop_todo.yml
+inherit_mode:
+  merge:
+    - Exclude
 
 AllCops:
   NewCops: disable
   SuggestExtensions: false
   TargetRubyVersion: 2.5
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Replace OpenStruct with regular class in `Zxcvbn::Match` for 2x performance improvement ([#61])
+ - Implement Trie data structure for dictionary matching with 1.4x additional performance improvement ([#62])
 
 [Unreleased]: https://github.com/envato/zxcvbn-ruby/compare/v1.2.4...HEAD
 [#61]: https://github.com/envato/zxcvbn-ruby/pull/61
+[#62]: https://github.com/envato/zxcvbn-ruby/pull/62
 
 ## [1.2.4] - 2025-12-07
 

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'zxcvbn/dictionary_ranker'
+require 'zxcvbn/trie'
 
 module Zxcvbn
   class Data
@@ -14,18 +15,31 @@ module Zxcvbn
         'surnames' => read_word_list('surnames.txt')
       )
       @adjacency_graphs = JSON.parse(DATA_PATH.join('adjacency_graphs.json').read)
+      @dictionary_tries = build_tries
     end
 
-    attr_reader :ranked_dictionaries, :adjacency_graphs
+    attr_reader :ranked_dictionaries, :adjacency_graphs, :dictionary_tries
 
     def add_word_list(name, list)
-      @ranked_dictionaries[name] = DictionaryRanker.rank_dictionary(list)
+      ranked_dict = DictionaryRanker.rank_dictionary(list)
+      @ranked_dictionaries[name] = ranked_dict
+      @dictionary_tries[name] = build_trie(ranked_dict)
     end
 
     private
 
     def read_word_list(file)
       DATA_PATH.join('frequency_lists', file).read.split
+    end
+
+    def build_tries
+      @ranked_dictionaries.transform_values { |dict| build_trie(dict) }
+    end
+
+    def build_trie(ranked_dictionary)
+      trie = Trie.new
+      ranked_dictionary.each { |word, rank| trie.insert(word, rank) }
+      trie
     end
   end
 end

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -38,7 +38,8 @@ module Zxcvbn
     def build_matchers
       matchers = []
       dictionary_matchers = @data.ranked_dictionaries.map do |name, dictionary|
-        Matchers::Dictionary.new(name, dictionary)
+        trie = @data.dictionary_tries[name]
+        Matchers::Dictionary.new(name, dictionary, trie)
       end
       l33t_matcher = Matchers::L33t.new(dictionary_matchers)
       matchers += dictionary_matchers

--- a/lib/zxcvbn/trie.rb
+++ b/lib/zxcvbn/trie.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Zxcvbn
+  # A trie (prefix tree) data structure for efficient dictionary matching.
+  # Provides fast prefix-based lookups to eliminate unnecessary substring checks.
+  #
+  # @see https://en.wikipedia.org/wiki/Trie
+  class Trie
+    def initialize
+      @root = {}
+    end
+
+    # Insert a word and its rank into the trie
+    # @param word [String] the word to insert
+    # @param rank [Integer] the rank/frequency of the word
+    def insert(word, rank)
+      node = @root
+      word.each_char do |char|
+        node[char] ||= {}
+        node = node[char]
+      end
+      node[:rank] = rank
+    end
+
+    # Search for all words in the text starting from a given position
+    # @param text [String] the text to search in
+    # @param start_pos [Integer] the starting position
+    # @return [Array<Array>] array of [word, rank, start, end] tuples
+    def search_prefixes(text, start_pos)
+      results = []
+      node = @root
+
+      (start_pos...text.length).each do |i|
+        char = text[i]
+        break unless node[char]
+
+        node = node[char]
+        results << [text[start_pos..i], node[:rank], start_pos, i] if node[:rank]
+      end
+
+      results
+    end
+  end
+end

--- a/spec/matchers/dictionary_spec.rb
+++ b/spec/matchers/dictionary_spec.rb
@@ -3,13 +3,88 @@
 require 'spec_helper'
 
 RSpec.describe Zxcvbn::Matchers::Dictionary do
-  subject(:matcher) { described_class.new('Test dictionary', dictionary) }
-
   describe '#matches' do
     let(:matches) { matcher.matches(password) }
     let(:matched_words) { matches.map(&:matched_word) }
 
+    context 'with Trie-based matching' do
+      subject(:matcher) { described_class.new('test', dictionary, trie) }
+
+      let(:dictionary) { { 'password' => 1, 'pass' => 2, 'word' => 3 } }
+      let(:trie) do
+        trie = Zxcvbn::Trie.new
+        dictionary.each { |word, rank| trie.insert(word, rank) }
+        trie
+      end
+      let(:password) { 'password123' }
+
+      it 'finds all matching dictionary words using trie' do
+        expect(matched_words).to match_array(%w[pass password word])
+      end
+
+      it 'creates matches with correct attributes' do
+        pass_match = matches.find { |m| m.matched_word == 'pass' }
+
+        expect(pass_match.i).to eq(0)
+        expect(pass_match.j).to eq(3)
+        expect(pass_match.token).to eq('pass')
+        expect(pass_match.rank).to eq(2)
+        expect(pass_match.pattern).to eq('dictionary')
+        expect(pass_match.dictionary_name).to eq('test')
+      end
+    end
+
+    context 'with hash-based matching (no trie)' do
+      subject(:matcher) { described_class.new('test', dictionary, nil) }
+
+      let(:dictionary) { { 'password' => 1, 'pass' => 2, 'word' => 3 } }
+      let(:password) { 'password123' }
+
+      it 'finds all matching dictionary words using hash lookup' do
+        expect(matched_words).to match_array(%w[pass password word])
+      end
+
+      it 'creates matches with correct attributes' do
+        pass_match = matches.find { |m| m.matched_word == 'pass' }
+
+        expect(pass_match.i).to eq(0)
+        expect(pass_match.j).to eq(3)
+        expect(pass_match.token).to eq('pass')
+        expect(pass_match.rank).to eq(2)
+        expect(pass_match.pattern).to eq('dictionary')
+        expect(pass_match.dictionary_name).to eq('test')
+      end
+    end
+
+    context 'comparing trie and hash implementations' do
+      let(:dictionary) { { 'test' => 1, 'testing' => 2, 'pass' => 3, 'password' => 4 } }
+      let(:password) { 'testpassword' }
+
+      let(:trie) do
+        trie = Zxcvbn::Trie.new
+        dictionary.each { |word, rank| trie.insert(word, rank) }
+        trie
+      end
+
+      let(:matcher_with_trie) { described_class.new('test', dictionary, trie) }
+      let(:matcher_without_trie) { described_class.new('test', dictionary, nil) }
+
+      it 'produces identical results' do
+        trie_results = matcher_with_trie.matches(password).map do |m|
+          [m.matched_word, m.i, m.j, m.rank]
+        end.sort
+
+        hash_results = matcher_without_trie.matches(password).map do |m|
+          [m.matched_word, m.i, m.j, m.rank]
+        end.sort
+
+        expect(trie_results).to eq(hash_results)
+      end
+    end
+
     context 'Given a dictionary of English words' do
+      subject(:matcher) { described_class.new('Test dictionary', dictionary) }
+
       let(:dictionary) { Zxcvbn::Data.new.ranked_dictionaries['english'] }
       let(:password) { 'whatisinit' }
 
@@ -19,6 +94,8 @@ RSpec.describe Zxcvbn::Matchers::Dictionary do
     end
 
     context 'Given a custom dictionary' do
+      subject(:matcher) { described_class.new('Test dictionary', dictionary) }
+
       let(:dictionary) { Zxcvbn::DictionaryRanker.rank_dictionary(%w[test AB10CD]) }
       let(:password) { 'AB10CD' }
 

--- a/spec/trie_spec.rb
+++ b/spec/trie_spec.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Zxcvbn::Trie do
+  let(:trie) { described_class.new }
+
+  describe '#initialize' do
+    it 'creates an empty trie' do
+      expect(trie).to be_a(described_class)
+    end
+  end
+
+  describe '#insert' do
+    it 'inserts a single word with rank' do
+      trie.insert('test', 1)
+      results = trie.search_prefixes('test', 0)
+
+      expect(results).to contain_exactly(['test', 1, 0, 3])
+    end
+
+    it 'inserts multiple words' do
+      trie.insert('test', 1)
+      trie.insert('testing', 2)
+      trie.insert('word', 3)
+
+      results = trie.search_prefixes('testing', 0)
+      expect(results).to contain_exactly(
+        ['test', 1, 0, 3],
+        ['testing', 2, 0, 6]
+      )
+    end
+
+    it 'handles words with common prefixes' do
+      trie.insert('pass', 1)
+      trie.insert('password', 2)
+      trie.insert('passwords', 3)
+
+      results = trie.search_prefixes('passwords', 0)
+      expect(results).to contain_exactly(
+        ['pass', 1, 0, 3],
+        ['password', 2, 0, 7],
+        ['passwords', 3, 0, 8]
+      )
+    end
+
+    it 'allows updating rank for existing word' do
+      trie.insert('test', 1)
+      trie.insert('test', 10)
+
+      results = trie.search_prefixes('test', 0)
+      expect(results).to contain_exactly(['test', 10, 0, 3])
+    end
+
+    it 'handles single character words' do
+      trie.insert('a', 1)
+      trie.insert('i', 2)
+
+      results = trie.search_prefixes('a', 0)
+      expect(results).to contain_exactly(['a', 1, 0, 0])
+    end
+
+    it 'handles empty string insertion gracefully' do
+      trie.insert('', 1)
+      results = trie.search_prefixes('test', 0)
+
+      expect(results).to be_empty
+    end
+  end
+
+  describe '#search_prefixes' do
+    before do
+      trie.insert('pass', 1)
+      trie.insert('password', 2)
+      trie.insert('test', 3)
+      trie.insert('testing', 4)
+      trie.insert('word', 5)
+    end
+
+    it 'finds all matching prefixes from start position' do
+      results = trie.search_prefixes('password', 0)
+
+      expect(results).to contain_exactly(
+        ['pass', 1, 0, 3],
+        ['password', 2, 0, 7]
+      )
+    end
+
+    it 'finds matches from different start positions' do
+      results = trie.search_prefixes('mypassword', 2)
+
+      expect(results).to contain_exactly(
+        ['pass', 1, 2, 5],
+        ['password', 2, 2, 9]
+      )
+    end
+
+    it 'returns empty array when no matches found' do
+      results = trie.search_prefixes('xyz', 0)
+
+      expect(results).to be_empty
+    end
+
+    it 'stops searching when prefix no longer matches' do
+      results = trie.search_prefixes('passfail', 0)
+
+      expect(results).to contain_exactly(['pass', 1, 0, 3])
+    end
+
+    it 'handles search beyond text length gracefully' do
+      results = trie.search_prefixes('test', 10)
+
+      expect(results).to be_empty
+    end
+
+    it 'handles start position at text boundary' do
+      results = trie.search_prefixes('test', 4)
+
+      expect(results).to be_empty
+    end
+
+    it 'returns results in order of appearance' do
+      results = trie.search_prefixes('testing', 0)
+
+      expect(results[0]).to eq(['test', 3, 0, 3])
+      expect(results[1]).to eq(['testing', 4, 0, 6])
+    end
+
+    it 'handles partial matches correctly' do
+      results = trie.search_prefixes('passw', 0)
+
+      expect(results).to contain_exactly(['pass', 1, 0, 3])
+    end
+
+    it 'finds multiple separate words in longer text' do
+      text = 'testwordpassword'
+
+      results_from_start = trie.search_prefixes(text, 0)
+      results_from_word = trie.search_prefixes(text, 4)
+      results_from_pass = trie.search_prefixes(text, 8)
+
+      # Only 'test' matches, not 'testing' because text continues with 'word'
+      expect(results_from_start).to contain_exactly(['test', 3, 0, 3])
+      expect(results_from_word).to contain_exactly(['word', 5, 4, 7])
+      expect(results_from_pass).to contain_exactly(
+        ['pass', 1, 8, 11],
+        ['password', 2, 8, 15]
+      )
+    end
+  end
+
+  describe 'integration with dictionary words' do
+    it 'handles common password dictionary words' do
+      common_words = {
+        'password' => 1,
+        '123456' => 2,
+        'qwerty' => 3,
+        'abc123' => 4,
+        'password123' => 5
+      }
+
+      common_words.each { |word, rank| trie.insert(word, rank) }
+
+      results = trie.search_prefixes('password123', 0)
+      expect(results).to contain_exactly(
+        ['password', 1, 0, 7],
+        ['password123', 5, 0, 10]
+      )
+    end
+
+    it 'handles name dictionaries' do
+      names = {
+        'john' => 1,
+        'jane' => 2,
+        'james' => 3,
+        'jennifer' => 4
+      }
+
+      names.each { |name, rank| trie.insert(name, rank) }
+
+      results = trie.search_prefixes('jamesbond', 0)
+      expect(results).to contain_exactly(['james', 3, 0, 4])
+    end
+
+    it 'handles case-insensitive matching' do
+      trie.insert('password', 1)
+
+      # Trie expects lowercased input (handled by matcher)
+      results = trie.search_prefixes('password', 0)
+      expect(results).to contain_exactly(['password', 1, 0, 7])
+    end
+  end
+
+  describe 'edge cases' do
+    it 'handles very long words' do
+      long_word = 'a' * 100
+      trie.insert(long_word, 1)
+
+      results = trie.search_prefixes(long_word, 0)
+      expect(results).to contain_exactly([long_word, 1, 0, 99])
+    end
+
+    it 'handles special characters' do
+      trie.insert('test@123', 1)
+      trie.insert('hello!world', 2)
+
+      results = trie.search_prefixes('test@123', 0)
+      expect(results).to contain_exactly(['test@123', 1, 0, 7])
+    end
+
+    it 'handles unicode characters' do
+      trie.insert('café', 1)
+      trie.insert('naïve', 2)
+
+      results = trie.search_prefixes('café', 0)
+      expect(results).to contain_exactly(['café', 1, 0, 3])
+    end
+
+    it 'handles numbers in words' do
+      trie.insert('123', 1)
+      trie.insert('abc123', 2)
+      trie.insert('123abc', 3)
+
+      results = trie.search_prefixes('123abc', 0)
+      expect(results).to contain_exactly(
+        ['123', 1, 0, 2],
+        ['123abc', 3, 0, 5]
+      )
+    end
+  end
+
+  describe 'performance characteristics' do
+    it 'efficiently handles large dictionaries' do
+      # Insert 1000 words
+      1000.times do |i|
+        trie.insert("word#{i}", i)
+      end
+
+      # NOTE: will find all prefix matches (word5, word50, word500)
+      results = trie.search_prefixes('word500', 0)
+      expect(results.last).to eq(['word500', 500, 0, 6])
+      expect(results.length).to be > 0
+    end
+
+    it 'early terminates on non-matching prefixes' do
+      trie.insert('apple', 1)
+      trie.insert('application', 2)
+
+      # Should terminate early when 'x' doesn't match
+      results = trie.search_prefixes('xyz', 0)
+      expect(results).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Context

Dictionary matching was using an O(n²) approach that checks every possible substring with hash lookups. This is inefficient because:

- For a 15-character password, it performs 120 substring checks
- Only ~6% of lookups succeed (hit rate)
- Creates many temporary string objects for failed lookups
- No early termination when prefixes don't match

## Changes

- Implemented `Zxcvbn::Trie` class for efficient prefix-based dictionary matching. See https://en.wikipedia.org/wiki/Trie
- Modified `Zxcvbn::Data` to build Trie structures alongside hash dictionaries
- Updated `Zxcvbn::Matchers::Dictionary` to use Trie with hash fallback for backward compatibility




## Consequences

- Performance improvement: 1.4x faster overall (0.333ms → 0.236ms per password test)
- Dictionary matching: 1.17x faster than hash-based approach
- Combined with PR #61: 2.83x total speedup from baseline (0.668ms → 0.236ms)
- Memory trade-off: Trie structures use ~2.1x more memory than hash tables (~14 MB combined for all dictionaries)
- Backward compatibility: Hash-based fallback ensures existing code continues to work

