### PR TITLE
Replace range operators with `String#slice` for string slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - Replace OpenStruct with regular class in `Zxcvbn::Match` for 2x performance improvement ([#61])
  - Implement Trie data structure for dictionary matching with 1.4x additional performance improvement ([#62])
+ - Replace range operators with `String#slice` for string slicing operations ([#63])
 
 [Unreleased]: https://github.com/envato/zxcvbn-ruby/compare/v1.2.4...HEAD
 [#61]: https://github.com/envato/zxcvbn-ruby/pull/61
 [#62]: https://github.com/envato/zxcvbn-ruby/pull/62
+[#63]: https://github.com/envato/zxcvbn-ruby/pull/63
 
 ## [1.2.4] - 2025-12-07
 

--- a/lib/zxcvbn/matchers/dictionary.rb
+++ b/lib/zxcvbn/matchers/dictionary.rb
@@ -31,7 +31,7 @@ module Zxcvbn
 
         (0...password.length).each do |i|
           @trie.search_prefixes(lowercased_password, i).each do |word, rank, start, ending|
-            results << build_match(word, password[start..ending], start, ending, rank)
+            results << build_match(word, password.slice(start, ending - start + 1), start, ending, rank)
           end
         end
 
@@ -44,10 +44,11 @@ module Zxcvbn
 
         (0..password_length).each do |i|
           (i...password_length).each do |j|
-            word = lowercased_password[i..j]
+            length = j - i + 1
+            word = lowercased_password.slice(i, length)
             next unless @ranked_dictionary.key?(word)
 
-            results << build_match(word, password[i..j], i, j, @ranked_dictionary[word])
+            results << build_match(word, password.slice(i, length), i, j, @ranked_dictionary[word])
           end
         end
 

--- a/lib/zxcvbn/matchers/l33t.rb
+++ b/lib/zxcvbn/matchers/l33t.rb
@@ -30,7 +30,8 @@ module Zxcvbn
           @dictionary_matchers.each do |matcher|
             subbed_password = translate(lowercased_password, substitution)
             matcher.matches(subbed_password).each do |match|
-              token = password[match.i..match.j]
+              length = match.j - match.i + 1
+              token = password.slice(match.i, length)
               next if token.downcase == match.matched_word.downcase
 
               match_substitutions = {}
@@ -38,7 +39,7 @@ module Zxcvbn
                 match_substitutions[s] = letter if token.include?(s)
               end
               match.l33t = true
-              match.token = password[match.i..match.j]
+              match.token = token
               match.sub = match_substitutions
               match.sub_display = match_substitutions.map do |k, v|
                 "#{k} -> #{v}"

--- a/lib/zxcvbn/matchers/new_l33t.rb
+++ b/lib/zxcvbn/matchers/new_l33t.rb
@@ -30,7 +30,8 @@ module Zxcvbn
           @dictionary_matchers.each do |matcher|
             subbed_password = substitute(lowercased_password, substitutions)
             matcher.matches(subbed_password).each do |match|
-              token = lowercased_password[match.i..match.j]
+              length = match.j - match.i + 1
+              token = lowercased_password.slice(match.i, length)
               next if token == match.matched_word.downcase
 
               match_substitutions = {}
@@ -38,7 +39,7 @@ module Zxcvbn
                 match_substitutions[substitution] = letter if token.include?(substitution)
               end
               match.l33t = true
-              match.token = password[match.i..match.j]
+              match.token = password.slice(match.i, length)
               match.sub = match_substitutions
               match.sub_display = match_substitutions.map do |k, v|
                 "#{k} -> #{v}"

--- a/lib/zxcvbn/matchers/regex_helpers.rb
+++ b/lib/zxcvbn/matchers/regex_helpers.rb
@@ -15,7 +15,7 @@ module Zxcvbn
           match = Match.new(
             i: i,
             j: j,
-            token: password[i..j]
+            token: password.slice(i, j - i + 1)
           )
           yield match, re_match
         end

--- a/lib/zxcvbn/matchers/repeat.rb
+++ b/lib/zxcvbn/matchers/repeat.rb
@@ -18,7 +18,7 @@ module Zxcvbn
               pattern: 'repeat',
               i: i,
               j: j - 1,
-              token: password[i...j],
+              token: password.slice(i, j - i),
               repeated_char: cur_char
             )
           end

--- a/lib/zxcvbn/matchers/spatial.rb
+++ b/lib/zxcvbn/matchers/spatial.rb
@@ -64,7 +64,7 @@ module Zxcvbn
                   pattern: 'spatial',
                   i: i,
                   j: j - 1,
-                  token: password[i...j],
+                  token: password.slice(i, j - i),
                   graph: graph_name,
                   turns: turns,
                   shifted_count: shifted_count

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -96,7 +96,7 @@ module Zxcvbn
         pattern: 'bruteforce',
         i: i,
         j: j,
-        token: password[i..j],
+        token: password.slice(i, j - i + 1),
         entropy: lg(bruteforce_cardinality**(j - i + 1)),
         cardinality: bruteforce_cardinality
       )


### PR DESCRIPTION


## Context

Throughout the codebase, string slicing operations use Ruby's range operators (`[i..j]` and `[i...j]`). The `String#slice(index, length)` method provides a more direct and efficient approach for extracting substrings, as it avoids the overhead of creating intermediate Range objects.

## Changes

Replaced all range-based string slicing operations with `String#slice(index, length)` across 7 files:

- `lib/zxcvbn/scorer.rb` - bruteforce match token extraction
- `lib/zxcvbn/matchers/dictionary.rb` - trie and hash-based matching
- `lib/zxcvbn/matchers/l33t.rb` - l33t substitution matching
- `lib/zxcvbn/matchers/new_l33t.rb` - alternative l33t implementation
- `lib/zxcvbn/matchers/regex_helpers.rb` - regex match token extraction
- `lib/zxcvbn/matchers/repeat.rb` - repeated character matching
- `lib/zxcvbn/matchers/spatial.rb` - keyboard pattern matching

All 244 existing tests pass, confirming the changes maintain identical behaviour.

## Considerations

Microbenchmarks show `String#slice` is approximately 35% faster than range operators for individual operations. However, end-to-end performance impact is negligible as string slicing represents a small fraction of overall execution time. The primary benefit is code consistency and avoiding unnecessary Range object allocations.