### PR TITLE
Optimise nCk calculation using symmetry property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Replace range operators with `String#slice` for string slicing operations ([#63])
  - Optimise L33t matcher with early bailout and improved deduplication ([#64])
  - Pre-compute spatial graph statistics during data initialisation ([#65])
+ - Optimise nCk calculation using symmetry property ([#66])
 
 [Unreleased]: https://github.com/envato/zxcvbn-ruby/compare/v1.2.4...HEAD
 [#61]: https://github.com/envato/zxcvbn-ruby/pull/61
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#63]: https://github.com/envato/zxcvbn-ruby/pull/63
 [#64]: https://github.com/envato/zxcvbn-ruby/pull/64
 [#65]: https://github.com/envato/zxcvbn-ruby/pull/65
+[#66]: https://github.com/envato/zxcvbn-ruby/pull/66
 
 ## [1.2.4] - 2025-12-07
 

--- a/lib/zxcvbn/math.rb
+++ b/lib/zxcvbn/math.rb
@@ -34,6 +34,10 @@ module Zxcvbn
       return 0 if k > n
       return 1 if k.zero?
 
+      # Use symmetry property: C(n,k) = C(n, n-k)
+      # Choose smaller k to minimize iterations
+      k = n - k if k > n - k
+
       r = 1
       (1..k).each do |d|
         r *= n


### PR DESCRIPTION

## Context

The `nCk` (binomial coefficient) calculation computes combinations using an iterative approach that loops from 1 to k. When k is large (e.g., calculating C(100, 95)), this results in many unnecessary iterations. The binomial coefficient has a mathematical symmetry property: C(n,k) = C(n,n-k), meaning the same result can be obtained by using the smaller value.

The symmetry exists because:
```
C(n,k) = n! / (k! × (n-k)!) = n! / ((n-k)! × k!) = C(n, n-k)
```

## Changes

Modified the `nCk` method in `lib/zxcvbn/math.rb` to use the smaller of k or (n-k):

```ruby
# Use symmetry property: C(n,k) = C(n, n-k)
# Choose smaller k to minimize iterations
k = n - k if k > n - k
```

This reduces loop iterations for large k values:
- C(100, 95) now calculated as C(100, 5) - 5 iterations instead of 95
- C(52, 47) now calculated as C(52, 5) - 5 iterations instead of 47
- C(20, 15) now calculated as C(20, 5) - 5 iterations instead of 15


## Consequences

**Performance improvement: 6.6x faster** (1.694µs → 0.256µs per calculation) for test cases with large k values.

All 291 tests pass, including existing tests that verify the symmetry property (`C(10,3) = C(10,7)` and `C(20,5) = C(20,15)`). The optimization uses a proven mathematical property and maintains identical behaviour whilst significantly improving performance.