### PR TITLE
Drop support for Ruby versions below 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['4.0', '3.4', '3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
+        ruby: ['4.0', '3.4', '3.3']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,6 @@ inherit_mode:
 AllCops:
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 2.5
 
 Metrics/BlockLength:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+ - Support for Ruby versions below 3.3 ([#70]).
+
 [Unreleased]: https://github.com/envato/zxcvbn-ruby/compare/v1.4.0...HEAD
+[#70]: https://github.com/envato/zxcvbn-ruby/pull/70
 
 ## [1.4.0] - 2026-01-15
 

--- a/lib/zxcvbn/entropy.rb
+++ b/lib/zxcvbn/entropy.rb
@@ -83,10 +83,10 @@ module Zxcvbn::Entropy
     match.base_entropy + match.uppercase_entropy + match.l33t_entropy
   end
 
-  START_UPPER = /^[A-Z][^A-Z]+$/.freeze
-  END_UPPER   = /^[^A-Z]+[A-Z]$/.freeze
-  ALL_UPPER   = /^[A-Z]+$/.freeze
-  ALL_LOWER   = /^[a-z]+$/.freeze
+  START_UPPER = /^[A-Z][^A-Z]+$/
+  END_UPPER   = /^[^A-Z]+[A-Z]$/
+  ALL_UPPER   = /^[A-Z]+$/
+  ALL_LOWER   = /^[a-z]+$/
 
   def extra_uppercase_entropy(match)
     word = match.token

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -25,7 +25,7 @@ module Zxcvbn
 
       # tie feedback to the longest match for longer sequences
       longest_match = sequence[0]
-      sequence[1..-1].each do |match|
+      sequence[1..].each do |match|
         longest_match = match if match.token.length > longest_match.token.length
       end
 

--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -13,7 +13,7 @@ module Zxcvbn
         ( \d{1,2} )                         # month or day
         \2                                  # same separator
         ( 19\d{2} | 200\d | 201\d | \d{2} ) # year
-      }x.freeze
+      }x
 
       YEAR_PREFIX = %r{
         ( 19\d{2} | 200\d | 201\d | \d{2} ) # year
@@ -21,9 +21,9 @@ module Zxcvbn
         ( \d{1,2} )                         # day or month
         \2                                  # same separator
         ( \d{1,2} )                         # month or day
-      }x.freeze
+      }x
 
-      WITHOUT_SEPARATOR = /\d{4,8}/.freeze
+      WITHOUT_SEPARATOR = /\d{4,8}/
 
       def matches(password)
         match_with_separator(password) + match_without_separator(password)

--- a/lib/zxcvbn/matchers/digits.rb
+++ b/lib/zxcvbn/matchers/digits.rb
@@ -7,7 +7,7 @@ module Zxcvbn
     class Digits
       include RegexHelpers
 
-      DIGITS_REGEX = /\d{3,}/.freeze
+      DIGITS_REGEX = /\d{3,}/
 
       def matches(password)
         result = []

--- a/lib/zxcvbn/matchers/l33t.rb
+++ b/lib/zxcvbn/matchers/l33t.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
-
 module Zxcvbn
   module Matchers
     class L33t
@@ -100,7 +98,7 @@ module Zxcvbn
         return subs if keys.empty?
 
         first_key = keys[0]
-        rest_keys = keys[1..-1]
+        rest_keys = keys[1..]
         next_subs = []
         table[first_key].each do |l33t_char|
           subs.each do |sub|

--- a/lib/zxcvbn/matchers/new_l33t.rb
+++ b/lib/zxcvbn/matchers/new_l33t.rb
@@ -110,7 +110,7 @@ module Zxcvbn
         return {} if hash.empty?
 
         values = hash.values
-        product_values = values[0].product(*values[1..-1])
+        product_values = values[0].product(*values[1..])
         product_values.map { |p| Hash[hash.keys.zip(p)] }
       end
     end

--- a/lib/zxcvbn/matchers/year.rb
+++ b/lib/zxcvbn/matchers/year.rb
@@ -7,7 +7,7 @@ module Zxcvbn
     class Year
       include RegexHelpers
 
-      YEAR_REGEX = /19\d\d|200\d|201\d/.freeze
+      YEAR_REGEX = /19\d\d|200\d|201\d/
 
       def matches(password)
         result = []

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = Zxcvbn::VERSION
   gem.license       = 'MIT'
 
-  gem.required_ruby_version = '>= 2.5'
+  gem.required_ruby_version = '>= 3.3'
 
   gem.metadata = {
     'allowed_push_host' => 'https://rubygems.org',


### PR DESCRIPTION
## Context

Ruby 3.3 is the oldest version still receiving security support. The gem currently declares a minimum Ruby version of 2.5.

## Changes

- Raise `required_ruby_version` to `>= 3.3` in the gemspec
- Remove Ruby 2.5, 2.6, 2.7, 3.0, 3.1, and 3.2 from the CI matrix
- Remove `TargetRubyVersion` from `.rubocop.yml` and autocorrect offenses unlocked by the newer target

## Consequences

Users on Ruby versions below 3.3 will no longer be able to install this gem. This is a breaking change and will require a major version bump at release.