### PR TITLE
Resolve RuboCop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -120,10 +120,8 @@ Style/GlobalVars:
     - 'spec/support/js_helpers.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, MinSize, WordRegex.
+# Configuration parameters: WordRegex.
 # SupportedStyles: percent, brackets
 Style/WordArray:
   Exclude:
     - 'lib/zxcvbn/matchers/l33t.rb'
-    - 'spec/dictionary_ranker_spec.rb'
-    - 'spec/matchers/sequences_spec.rb'

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -53,8 +53,8 @@ module Zxcvbn
         starting_positions = graph.length
 
         stats[graph_name] = {
-          average_degree: average_degree,
-          starting_positions: starting_positions
+          average_degree:,
+          starting_positions:
         }
       end
       stats

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -54,7 +54,7 @@ module Zxcvbn
                   end
 
         Feedback.new(
-          warning: warning,
+          warning:,
           suggestions: [
             'Use a longer keyboard pattern with more turns'
           ]
@@ -68,7 +68,7 @@ module Zxcvbn
             'Repeats like "abcabcabc" are only slightly harder to guess than "abc"'
           end
         Feedback.new(
-          warning: warning,
+          warning:,
           suggestions: [
             'Avoid repeated words and characters'
           ]
@@ -143,10 +143,7 @@ don't help very much"
         )
       end
 
-      Feedback.new(
-        warning: warning,
-        suggestions: suggestions
-      )
+      Feedback.new(warning:, suggestions:)
     end
   end
 end

--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -48,7 +48,7 @@ module Zxcvbn
         when 'bruteforce' then bruteforce_guesses(match)
         when 'dictionary' then dictionary_guesses(match)
         when 'spatial'    then spatial_guesses(match)
-        when 'repeat'     then repeat_guesses(match, user_inputs: user_inputs)
+        when 'repeat'     then repeat_guesses(match, user_inputs:)
         when 'sequence'   then sequence_guesses(match)
         when 'digits'     then digits_guesses(match)
         when 'year'       then year_guesses(match)
@@ -133,7 +133,7 @@ module Zxcvbn
       (2..token_length).each do |i|
         possible_turns = [turns, i - 1].min
         (1..possible_turns).each do |j|
-          guesses += nCk(i - 1, j - 1) * s * d**j
+          guesses += nCk(i - 1, j - 1) * s * (d**j)
         end
       end
 

--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -53,8 +53,8 @@ module Zxcvbn
         result = []
         return result if password.length < 6
 
-        (0..password.length - 6).each do |i|
-          (i + 5..[i + 9, password.length - 1].min).each do |j|
+        (0..(password.length - 6)).each do |i|
+          ((i + 5)..[i + 9, password.length - 1].min).each do |j|
             token = password[i..j]
             m = MAYBE_DATE_WITH_SEP.match(token)
             next unless m
@@ -63,7 +63,7 @@ module Zxcvbn
             next unless date
 
             result << Match.new(
-              i: i, j: j, token: token,
+              i:, j:, token:,
               pattern: 'date',
               separator: m[2],
               year: date[:year],
@@ -89,8 +89,8 @@ module Zxcvbn
         result = []
         return result if password.length < 4
 
-        (0..password.length - 4).each do |i|
-          (i + 3..[i + 7, password.length - 1].min).each do |j|
+        (0..(password.length - 4)).each do |i|
+          ((i + 3)..[i + 7, password.length - 1].min).each do |j|
             token = password[i..j]
             next unless MAYBE_DATE_WITHOUT_SEP.match?(token)
 
@@ -107,7 +107,7 @@ module Zxcvbn
             best = candidates.min_by { |c| (c[:year] - reference_year).abs }
 
             result << Match.new(
-              i: i, j: j, token: token,
+              i:, j:, token:,
               pattern: 'date',
               separator: '',
               year: best[:year],
@@ -150,7 +150,7 @@ module Zxcvbn
         # If a 4-digit candidate is found but day/month are invalid, return nil immediately
         # rather than falling through to the 2-digit pass.
         pairs = [[int3, int1, int2], [int1, int2, int3]]
-        four_digit = pairs.find { |yc, _dm1, _dm2| yc >= DATE_MIN_YEAR && yc <= DATE_MAX_YEAR }
+        four_digit = pairs.find { |yc, _dm1, _dm2| yc.between?(DATE_MIN_YEAR, DATE_MAX_YEAR) }
         if four_digit
           year_candidate, dm1, dm2 = four_digit
           dm = map_ints_to_dm(dm1, dm2)
@@ -177,7 +177,7 @@ module Zxcvbn
       # @return [Hash, nil] +{day:, month:}+ or +nil+ if neither ordering is valid
       def map_ints_to_dm(day_val, month_val)
         [[day_val, month_val], [month_val, day_val]].each do |day, month|
-          return { day: day, month: month } if day >= 1 && day <= 31 && month >= 1 && month <= 12
+          return { day:, month: } if day.between?(1, 31) && month >= 1 && month <= 12
         end
         nil
       end

--- a/lib/zxcvbn/matchers/dictionary.rb
+++ b/lib/zxcvbn/matchers/dictionary.rb
@@ -57,11 +57,11 @@ module Zxcvbn
 
       def build_match(matched_word, token, start_pos, end_pos, rank)
         Match.new(
-          matched_word: matched_word,
-          token: token,
+          matched_word:,
+          token:,
           i: start_pos,
           j: end_pos,
-          rank: rank,
+          rank:,
           pattern: 'dictionary',
           dictionary_name: @name
         )

--- a/lib/zxcvbn/matchers/regex_helpers.rb
+++ b/lib/zxcvbn/matchers/regex_helpers.rb
@@ -12,11 +12,7 @@ module Zxcvbn
           pos = j
           j -= 1
 
-          match = Match.new(
-            i: i,
-            j: j,
-            token: password.slice(i, j - i + 1)
-          )
+          match = Match.new(i:, j:, token: password.slice(i, j - i + 1))
           yield match, re_match
         end
       end

--- a/lib/zxcvbn/matchers/repeat.rb
+++ b/lib/zxcvbn/matchers/repeat.rb
@@ -42,10 +42,10 @@ module Zxcvbn
 
           result << Match.new(
             pattern: 'repeat',
-            i: i,
-            j: j,
-            token: token,
-            base_token: base_token,
+            i:,
+            j:,
+            token:,
+            base_token:,
             repeat_count: token.length / base_token.length
           )
 

--- a/lib/zxcvbn/matchers/sequences.rb
+++ b/lib/zxcvbn/matchers/sequences.rb
@@ -32,7 +32,7 @@ module Zxcvbn
             pattern: 'sequence',
             i: start,
             j: seq_end,
-            token: token,
+            token:,
             sequence_name: seq_name,
             sequence_space: seq_space,
             ascending: delta.positive?

--- a/lib/zxcvbn/matchers/spatial.rb
+++ b/lib/zxcvbn/matchers/spatial.rb
@@ -65,12 +65,12 @@ module Zxcvbn
               if j - i > 2 # don't consider length 1 or 2 chains.
                 result << Match.new(
                   pattern: 'spatial',
-                  i: i,
+                  i:,
                   j: j - 1,
                   token: password.slice(i, j - i),
                   graph: graph_name,
-                  turns: turns,
-                  shifted_count: shifted_count
+                  turns:,
+                  shifted_count:
                 )
               end
               # ...and then start a new search for the rest of the password.

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -19,7 +19,7 @@ module Zxcvbn
       result = nil
       calc_time = Clock.realtime do
         matches = @omnimatch.matches(password, user_inputs)
-        result = @scorer.most_guessable_match_sequence(password, matches, user_inputs: user_inputs)
+        result = @scorer.most_guessable_match_sequence(password, matches, user_inputs:)
       end
       result.calc_time = calc_time
       result.feedback = FeedbackGiver.get_feedback(result.score, result.sequence)

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -52,7 +52,7 @@ module Zxcvbn
 
       update = lambda do |match, l|
         j   = match.j
-        est = estimate_guesses(match, password, user_inputs: user_inputs)
+        est = estimate_guesses(match, password, user_inputs:)
         est *= pi[match.i - 1][l - 1] if l > 1
         candidate = factorial(l) * est
         candidate += MIN_GUESSES_BEFORE_GROWING_SEQUENCE.to_f**(l - 1) unless exclude_additive
@@ -65,7 +65,7 @@ module Zxcvbn
       end
 
       make_bruteforce = lambda do |i, j|
-        Match.new(pattern: 'bruteforce', token: password.slice(i, j - i + 1), i: i, j: j)
+        Match.new(pattern: 'bruteforce', token: password.slice(i, j - i + 1), i:, j:)
       end
 
       (0...n).each do |k|
@@ -117,8 +117,7 @@ module Zxcvbn
         require 'zxcvbn/omnimatch'
         @omnimatch ||= Omnimatch.new(@data)
         base_matches  = @omnimatch.matches(match.base_token, user_inputs)
-        base_analysis = most_guessable_match_sequence(match.base_token, base_matches,
-                                                      user_inputs: user_inputs)
+        base_analysis = most_guessable_match_sequence(match.base_token, base_matches, user_inputs:)
         match.base_guesses = base_analysis.guesses
       end
       match.base_guesses * match.repeat_count
@@ -133,9 +132,9 @@ module Zxcvbn
     def build_score(password, sequence, guesses)
       attack_times = estimate_attack_times(guesses)
       Score.new(
-        password: password,
-        guesses: guesses,
-        sequence: sequence,
+        password:,
+        guesses:,
+        sequence:,
         crack_times_seconds: attack_times[:crack_times_seconds],
         crack_times_display: attack_times[:crack_times_display],
         score: guesses_to_score(guesses)

--- a/spec/dictionary_ranker_spec.rb
+++ b/spec/dictionary_ranker_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 RSpec.describe Zxcvbn::DictionaryRanker do
   describe '.rank_dictionaries' do
     it 'ranks word lists' do
-      result = Zxcvbn::DictionaryRanker.rank_dictionaries({ test: ['ABC', 'def'],
-                                                            test2: ['def', 'ABC'] })
+      result = Zxcvbn::DictionaryRanker.rank_dictionaries({ test: %w[ABC def],
+                                                            test2: %w[def ABC] })
       expect(result[:test]).to eq({ 'abc' => 1, 'def' => 2 })
       expect(result[:test2]).to eq({ 'def' => 1, 'abc' => 2 })
     end

--- a/spec/guesses_spec.rb
+++ b/spec/guesses_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Zxcvbn::Guesses do
   let(:host) do
     Class.new do
       include Zxcvbn::Guesses
+
       attr_reader :data
 
       def initialize(data = nil)
@@ -234,7 +235,7 @@ RSpec.describe Zxcvbn::Guesses do
 
     it 'dispatches to date_guesses for date pattern' do
       year = Time.now.year - 30
-      m = make_match(pattern: 'date', token: '021297', year: year, separator: '')
+      m = make_match(pattern: 'date', token: '021297', year:, separator: '')
       expect(host.estimate_guesses(m, '021297')).to eq 365 * 30
     end
   end

--- a/spec/matchers/sequences_spec.rb
+++ b/spec/matchers/sequences_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe Zxcvbn::Matchers::Sequences do
 
   it 'finds overlapping matches' do
     matches = matcher.matches('abcba')
-    expect(matches.map(&:token)).to eq ['abc', 'cba']
+    expect(matches.map(&:token)).to eq %w[abc cba]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'bundler/setup'
 require 'rspec'
 require 'zxcvbn'
 
-Dir[Pathname.new(File.expand_path(__dir__)).join('support/**/*.rb')].sort.each { |f| require f }
+Dir[Pathname.new(File.expand_path(__dir__)).join('support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.include JsHelpers

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
     'changelog_uri' => "#{gem.homepage}/blob/HEAD/CHANGELOG.md",
     'documentation_uri' => "https://www.rubydoc.info/gems/#{gem.name}/#{gem.version}",
     'homepage_uri' => gem.homepage,
-    'source_code_uri' => "#{gem.homepage}/tree/v#{gem.version}"
+    'source_code_uri' => "#{gem.homepage}/tree/v#{gem.version}",
+    'rubygems_mfa_required' => 'true'
   }
 end


### PR DESCRIPTION
## Context

The codebase has a number of RuboCop offenses, including ambiguous operator and range expressions, verbose hash syntax, and missing gemspec metadata.

## Changes

- Parenthesize ambiguous operator/range expressions (`Lint/AmbiguousOperatorPrecedence`, `Lint/AmbiguousRange`)
- Use `.between?` for range comparisons (`Style/ComparableBetween`)
- Use `%w[]` word arrays (`Style/WordArray`)
- Use Ruby 3.1+ shorthand hash syntax (`Style/HashShorthand`)
- Add `rubygems_mfa_required` to gemspec metadata (`Gemspec/RequireMFA`)
- Remove redundant `Dir.sort` in spec_helper (`Lint/RedundantDirGlobSort`)
- Remove resolved exclusions from `.rubocop_todo.yml`

## Consequences

`bundle exec rubocop` reports no offenses.