### PR TITLE
Add YARD documentation to all public classes, modules, and methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -91,29 +91,6 @@ Naming/MethodParameterName:
     - 'lib/zxcvbn/math.rb'
     - 'lib/zxcvbn/scorer.rb'
 
-# Configuration parameters: AllowedConstants.
-Style/Documentation:
-  Exclude:
-    - 'lib/zxcvbn.rb'
-    - 'lib/zxcvbn/clock.rb'
-    - 'lib/zxcvbn/crack_time.rb'
-    - 'lib/zxcvbn/data.rb'
-    - 'lib/zxcvbn/dictionary_ranker.rb'
-    - 'lib/zxcvbn/feedback.rb'
-    - 'lib/zxcvbn/feedback_giver.rb'
-    - 'lib/zxcvbn/match.rb'
-    - 'lib/zxcvbn/matchers/dictionary.rb'
-    - 'lib/zxcvbn/matchers/digits.rb'
-    - 'lib/zxcvbn/matchers/l33t.rb'
-    - 'lib/zxcvbn/matchers/regex_helpers.rb'
-    - 'lib/zxcvbn/matchers/sequences.rb'
-    - 'lib/zxcvbn/matchers/spatial.rb'
-    - 'lib/zxcvbn/matchers/year.rb'
-    - 'lib/zxcvbn/math.rb'
-    - 'lib/zxcvbn/omnimatch.rb'
-    - 'lib/zxcvbn/password_strength.rb'
-    - 'lib/zxcvbn/score.rb'
-
 # Configuration parameters: AllowedVariables.
 Style/GlobalVars:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Reverse dictionary matching in `Omnimatch` so reversed words (e.g. "drowssap") are detected and scored ([#69])
  - `guesses` and `guesses_log10` fields on `Zxcvbn::Score` ([#69])
  - `guesses`, `guesses_log10`, `base_token`, `repeat_count`, and `base_guesses` fields on `Zxcvbn::Match` ([#69])
+ - YARD documentation for all public classes, modules, and methods ([#72])
 
 ### Changed
  - **Breaking**: Scoring algorithm aligned with zxcvbn.js v4.4.2. The dynamic programming step now minimises total guesses (`factorial(l) × cumulative_product + MIN_GUESSES^(l-1)` penalty) instead of entropy bits. Scores for many passwords will change ([#69])
@@ -35,9 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
  - Support for Ruby versions below 3.3 ([#70])
 
+
 [Unreleased]: https://github.com/envato/zxcvbn-ruby/compare/v1.4.0...HEAD
 [#69]: https://github.com/envato/zxcvbn-ruby/pull/69
 [#70]: https://github.com/envato/zxcvbn-ruby/pull/70
+[#72]: https://github.com/envato/zxcvbn-ruby/pull/72
 
 ## [1.4.0] - 2026-01-15
 

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -4,6 +4,11 @@ require 'pathname'
 require 'zxcvbn/version'
 require 'zxcvbn/tester'
 
+# Ruby port of zxcvbn.js — realistic password strength estimation.
+#
+# Analyses a password against dictionary lists, keyboard patterns, dates,
+# sequences, and repeats to produce a {Score} with guess estimates and
+# human-readable crack-time display strings.
 module Zxcvbn
   module_function
 

--- a/lib/zxcvbn/clock.rb
+++ b/lib/zxcvbn/clock.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  # Monotonic-clock utility for measuring elapsed wall time.
   module Clock
+    # Yields to the block and returns the elapsed time in seconds.
+    #
+    # @yield block whose execution time is measured
+    # @return [Float] elapsed seconds as a monotonic-clock duration
     def self.realtime
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       yield

--- a/lib/zxcvbn/crack_time.rb
+++ b/lib/zxcvbn/crack_time.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  # Mixin that converts a guess count into estimated crack times and scores.
+  #
+  # Provides {estimate_attack_times}, {guesses_to_score}, and {display_time}
+  # mirroring the crack-time logic from zxcvbn.js v4.
   module CrackTime
     ATTACK_SCENARIOS = {
       'online_throttling_100_per_hour' => 100.0 / 3600,
@@ -42,6 +46,10 @@ module Zxcvbn
       end
     end
 
+    # Convert a number of seconds into a human-readable display string.
+    #
+    # @param seconds [Numeric] duration in seconds
+    # @return [String] e.g. "instant", "3 minutes", "centuries"
     def display_time(seconds)
       minute  = 60
       hour    = minute * 60

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -5,7 +5,15 @@ require 'zxcvbn/dictionary_ranker'
 require 'zxcvbn/trie'
 
 module Zxcvbn
+  # Holds all loaded frequency lists, adjacency graphs, tries, and graph stats
+  # used by the matchers and scorer.
+  #
+  # @attr_reader ranked_dictionaries [Hash{String => Hash{String => Integer}}] word → rank maps
+  # @attr_reader adjacency_graphs [Hash{String => Hash}] keyboard adjacency data
+  # @attr_reader dictionary_tries [Hash{String => Trie}] prefix tries per dictionary
+  # @attr_reader graph_stats [Hash{String => Hash}] precomputed average degree and key count
   class Data
+    # Loads all built-in frequency lists and adjacency graphs from disk.
     def initialize
       @ranked_dictionaries = DictionaryRanker.rank_dictionaries(
         'english' => read_word_list('english.txt'),
@@ -22,6 +30,11 @@ module Zxcvbn
 
     attr_reader :ranked_dictionaries, :adjacency_graphs, :dictionary_tries, :graph_stats
 
+    # Adds a custom word list and builds a trie for it.
+    #
+    # @param name [String] dictionary name (used as a key in {#ranked_dictionaries})
+    # @param list [Array<String>] ordered words (most common first)
+    # @return [void]
     def add_word_list(name, list)
       ranked_dict = DictionaryRanker.rank_dictionary(list)
       @ranked_dictionaries[name] = ranked_dict

--- a/lib/zxcvbn/dictionary_ranker.rb
+++ b/lib/zxcvbn/dictionary_ranker.rb
@@ -1,13 +1,22 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  # Converts raw word lists into frequency-ranked dictionaries for matcher use.
   class DictionaryRanker
+    # Ranks multiple word lists, returning a hash of ranked dictionaries.
+    #
+    # @param lists [Hash{Symbol => Array<String>}] named word lists
+    # @return [Hash{Symbol => Hash{String => Integer}}] lowercased word → rank mappings
     def self.rank_dictionaries(lists)
       lists.transform_values do |words|
         rank_dictionary(words)
       end
     end
 
+    # Ranks a single word list; rank starts at 1 (most common).
+    #
+    # @param words [Array<String>] ordered words (most common first)
+    # @return [Hash{String => Integer}] lowercased word → 1-based rank
     def self.rank_dictionary(words)
       words
         .each_with_index

--- a/lib/zxcvbn/feedback.rb
+++ b/lib/zxcvbn/feedback.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  # Human-readable feedback for a low-scoring password.
+  #
+  # @!attribute [rw] warning
+  #   @return [String] a single warning message, or empty string
+  # @!attribute [rw] suggestions
+  #   @return [Array<String>] ordered list of improvement tips
   class Feedback
     attr_accessor :warning, :suggestions
 
+    # @param options [Hash]
+    # @option options [String] :warning warning message (default: empty string)
+    # @option options [Array<String>] :suggestions improvement tips (default: [])
     def initialize(options = {})
       @warning     = options[:warning] || ''
       @suggestions = options[:suggestions] || []

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -4,6 +4,7 @@ require 'zxcvbn/guesses'
 require 'zxcvbn/feedback'
 
 module Zxcvbn
+  # Generates human-readable {Feedback} for a password given its score and match sequence.
   class FeedbackGiver
     NAME_DICTIONARIES = %w[surnames male_names female_names].freeze
 
@@ -16,6 +17,11 @@ module Zxcvbn
 
     EMPTY_FEEDBACK = Feedback.new.freeze
 
+    # Returns feedback appropriate for the given score and match sequence.
+    #
+    # @param score [Integer] 0–4 score from the scorer
+    # @param sequence [Array<Match>] optimal match sequence
+    # @return [Feedback]
     def self.get_feedback(score, sequence)
       # starting feedback
       return DEFAULT_FEEDBACK if sequence.empty?
@@ -41,6 +47,11 @@ module Zxcvbn
       feedback
     end
 
+    # Returns pattern-specific feedback for a single match, or nil if none applies.
+    #
+    # @param match [Match]
+    # @param is_sole_match [Boolean] true when this is the only match in the sequence
+    # @return [Feedback, nil]
     def self.get_match_feedback(match, is_sole_match)
       case match.pattern
       when 'dictionary'
@@ -101,6 +112,11 @@ module Zxcvbn
       end
     end
 
+    # Returns feedback specific to a dictionary match.
+    #
+    # @param match [Match] a dictionary pattern match
+    # @param is_sole_match [Boolean] true when this is the only match in the sequence
+    # @return [Feedback]
     def self.get_dictionary_match_feedback(match, is_sole_match)
       warning =
         if match.dictionary_name == 'passwords'

--- a/lib/zxcvbn/match.rb
+++ b/lib/zxcvbn/match.rb
@@ -1,6 +1,67 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  # A substring match found by one of the pattern matchers.
+  #
+  # Attributes are set dynamically via {#initialize}; only the attributes
+  # relevant to the matched pattern will be populated.
+  #
+  # @!attribute [rw] pattern
+  #   @return [String] the matcher that produced this match
+  # @!attribute [rw] i
+  #   @return [Integer] start index in the password (inclusive)
+  # @!attribute [rw] j
+  #   @return [Integer] end index in the password (inclusive)
+  # @!attribute [rw] token
+  #   @return [String] the matched substring
+  # @!attribute [rw] matched_word
+  #   @return [String] lowercased dictionary word (dictionary matches)
+  # @!attribute [rw] rank
+  #   @return [Integer] frequency rank of the matched word (dictionary matches)
+  # @!attribute [rw] dictionary_name
+  #   @return [String] source dictionary name (dictionary matches)
+  # @!attribute [rw] reversed
+  #   @return [Boolean] true when matched in the reversed password
+  # @!attribute [rw] l33t
+  #   @return [Boolean] true when the match required l33t substitution
+  # @!attribute [rw] sub
+  #   @return [Hash] map of l33t characters to their substituted letters
+  # @!attribute [rw] sub_display
+  #   @return [String] human-readable substitution summary
+  # @!attribute [rw] guesses
+  #   @return [Integer] estimated guess count
+  # @!attribute [rw] guesses_log10
+  #   @return [Float] log10 of {#guesses}
+  # @!attribute [rw] base_guesses
+  #   @return [Integer] guesses for the base token (repeat matches)
+  # @!attribute [rw] uppercase_variations
+  #   @return [Integer] capitalisation variant count
+  # @!attribute [rw] l33t_variations
+  #   @return [Integer] l33t substitution variant count
+  # @!attribute [rw] base_token
+  #   @return [String] the minimal repeating unit (repeat matches)
+  # @!attribute [rw] repeat_count
+  #   @return [Integer] number of repetitions (repeat matches)
+  # @!attribute [rw] sequence_name
+  #   @return [String] sequence type: "lower", "upper", "digits", or "unicode"
+  # @!attribute [rw] sequence_space
+  #   @return [Integer] size of the character set for the sequence
+  # @!attribute [rw] ascending
+  #   @return [Boolean] true if the sequence is ascending
+  # @!attribute [rw] graph
+  #   @return [String] keyboard graph name (spatial matches)
+  # @!attribute [rw] turns
+  #   @return [Integer] number of direction changes (spatial matches)
+  # @!attribute [rw] shifted_count
+  #   @return [Integer] number of shifted characters (spatial matches)
+  # @!attribute [rw] year
+  #   @return [Integer] matched year (date/year matches)
+  # @!attribute [rw] month
+  #   @return [Integer] matched month (date matches)
+  # @!attribute [rw] day
+  #   @return [Integer] matched day (date matches)
+  # @!attribute [rw] separator
+  #   @return [String] date separator character (date matches)
   class Match
     attr_accessor :pattern, :i, :j, :token, :matched_word, :rank,
                   :dictionary_name, :reversed, :l33t, :sub, :sub_display,
@@ -10,12 +71,16 @@ module Zxcvbn
                   :graph, :turns, :shifted_count,
                   :year, :month, :day, :separator
 
+    # @param attributes [Hash] keyword arguments for any subset of the match attributes
     def initialize(**attributes)
       attributes.each do |key, value|
         instance_variable_set("@#{key}", value)
       end
     end
 
+    # Returns all non-nil attributes as a plain Hash with string keys.
+    #
+    # @return [Hash{String => Object}]
     def to_hash
       instance_variables.sort.each_with_object({}) do |var, hash|
         key = var.to_s.delete_prefix('@')

--- a/lib/zxcvbn/matchers/dictionary.rb
+++ b/lib/zxcvbn/matchers/dictionary.rb
@@ -4,16 +4,22 @@ require 'zxcvbn/match'
 
 module Zxcvbn
   module Matchers
-    # Given a password and a dictionary, match on any sequential segment of
-    # the lowercased password in the dictionary
-
+    # Matches any sequential segment of the lowercased password that appears in
+    # a ranked dictionary.
     class Dictionary
+      # @param name [String] dictionary identifier used in match results
+      # @param ranked_dictionary [Hash{String => Integer}] lowercased word → rank
+      # @param trie [Trie, nil] optional prefix trie for faster lookups
       def initialize(name, ranked_dictionary, trie = nil)
         @name = name
         @ranked_dictionary = ranked_dictionary
         @trie = trie
       end
 
+      # Returns all dictionary matches found in password.
+      #
+      # @param password [String]
+      # @return [Array<Match>] matches with pattern "dictionary"
       def matches(password)
         lowercased_password = password.downcase
 

--- a/lib/zxcvbn/matchers/digits.rb
+++ b/lib/zxcvbn/matchers/digits.rb
@@ -4,11 +4,15 @@ require 'zxcvbn/matchers/regex_helpers'
 
 module Zxcvbn
   module Matchers
+    # Matches runs of 3 or more consecutive digits in the password.
     class Digits
       include RegexHelpers
 
+      # Matches runs of 3 or more consecutive digits.
       DIGITS_REGEX = /\d{3,}/
 
+      # @param password [String]
+      # @return [Array<Match>] matches with pattern "digits"
       def matches(password)
         result = []
         re_match_all(DIGITS_REGEX, password) do |match|

--- a/lib/zxcvbn/matchers/l33t.rb
+++ b/lib/zxcvbn/matchers/l33t.rb
@@ -2,7 +2,10 @@
 
 module Zxcvbn
   module Matchers
+    # Matches dictionary words after substituting common l33t-speak character
+    # replacements (e.g. "@" for "a", "3" for "e").
     class L33t
+      # Mapping from plain letter to the l33t characters that can represent it.
       L33T_TABLE = {
         'a' => ['4', '@'].freeze,
         'b' => ['8'].freeze,
@@ -18,10 +21,15 @@ module Zxcvbn
         'z' => ['2'].freeze
       }.freeze
 
+      # @param dictionary_matchers [Array<Dictionary>] matchers to run against substituted passwords
       def initialize(dictionary_matchers)
         @dictionary_matchers = dictionary_matchers
       end
 
+      # Returns l33t-substituted dictionary matches found in password.
+      #
+      # @param password [String]
+      # @return [Array<Match>] matches with pattern "dictionary" and l33t: true
       def matches(password)
         matches = []
         lowercased_password = password.downcase
@@ -42,6 +50,11 @@ module Zxcvbn
         matches
       end
 
+      # Returns a copy of password with each character replaced according to sub.
+      #
+      # @param password [String]
+      # @param sub [Hash{String => String}] character substitution map
+      # @return [String]
       def translate(password, sub)
         result = String.new
         password.each_char do |chr|
@@ -50,6 +63,10 @@ module Zxcvbn
         result
       end
 
+      # Returns the subset of {L33T_TABLE} whose l33t characters appear in password.
+      #
+      # @param password [String] lowercased password
+      # @return [Hash{String => Array<String>}]
       def relevent_l33t_subtable(password)
         filtered = {}
         L33T_TABLE.each do |letter, subs|
@@ -59,6 +76,10 @@ module Zxcvbn
         filtered
       end
 
+      # Enumerates all possible substitution combinations for the given l33t subtable.
+      #
+      # @param table [Hash{String => Array<String>}] relevant l33t subtable
+      # @return [Array<Hash{String => String}>] list of substitution maps to try
       def l33t_subs(table)
         keys = table.keys
         subs = [[]]

--- a/lib/zxcvbn/matchers/regex_helpers.rb
+++ b/lib/zxcvbn/matchers/regex_helpers.rb
@@ -3,8 +3,18 @@
 require 'zxcvbn/match'
 
 module Zxcvbn
+  # Namespace for all password pattern matchers.
   module Matchers
+    # Shared helper for iterating non-overlapping regex matches over a password.
     module RegexHelpers
+      # Yields a {Match} and the underlying MatchData for every non-overlapping
+      # occurrence of regex in password.
+      #
+      # @param regex [Regexp] pattern to search for
+      # @param password [String] the password to search
+      # @yieldparam match [Match] match with i, j, and token set
+      # @yieldparam re_match [MatchData] the underlying MatchData object
+      # @return [void]
       def re_match_all(regex, password)
         pos = 0
         while (re_match = regex.match(password, pos))

--- a/lib/zxcvbn/matchers/repeat.rb
+++ b/lib/zxcvbn/matchers/repeat.rb
@@ -10,8 +10,11 @@ module Zxcvbn
     # prefer the greedier match unless the lazy match is longer, then use
     # LAZY_ANCHORED to extract the minimal repeating unit (base_token).
     class Repeat
+      # Greedily matches the longest repeated substring.
       GREEDY        = /(.+)\1+/
+      # Lazily matches the shortest repeated substring.
       LAZY          = /(.+?)\1+/
+      # Anchored lazy pattern used to extract the minimal base token.
       LAZY_ANCHORED = /^(.+?)\1+$/
 
       # Find all repeated-substring matches in the password.

--- a/lib/zxcvbn/matchers/sequences.rb
+++ b/lib/zxcvbn/matchers/sequences.rb
@@ -4,12 +4,20 @@ require 'zxcvbn/match'
 
 module Zxcvbn
   module Matchers
+    # Matches monotonically incrementing or decrementing character sequences,
+    # such as "abcde", "54321", or "ZYXW".
     class Sequences
+      # Maximum absolute step between adjacent characters for a valid sequence.
       MAX_DELTA  = 5
+      # Matches tokens that are all lowercase letters.
       ALL_LOWER  = /^[a-z]+$/
+      # Matches tokens that are all uppercase letters.
       ALL_UPPER  = /^[A-Z]+$/
+      # Matches tokens that are all digits.
       ALL_DIGITS = /^\d+$/
 
+      # @param password [String]
+      # @return [Array<Match>] matches with pattern "sequence"
       def matches(password)
         return [] if password.length == 1
 

--- a/lib/zxcvbn/matchers/spatial.rb
+++ b/lib/zxcvbn/matchers/spatial.rb
@@ -4,13 +4,19 @@ require 'zxcvbn/match'
 
 module Zxcvbn
   module Matchers
+    # Matches keyboard spatial patterns (e.g. "qwerty", "asdf") across all
+    # configured adjacency graphs.
     class Spatial
+      # Matches characters that require the Shift key on a standard keyboard.
       SHIFTED_RX = /[~!@#$%^&*()\-_+QWERTYUIOP{}|ASDFGHJKL:"ZXCVBNM<>?]/
 
+      # @param graphs [Hash{String => Hash}] adjacency graph data keyed by graph name
       def initialize(graphs)
         @graphs = graphs
       end
 
+      # @param password [String]
+      # @return [Array<Match>] matches with pattern "spatial" across all graphs
       def matches(password)
         results = []
         @graphs.each do |graph_name, graph|
@@ -19,6 +25,12 @@ module Zxcvbn
         results
       end
 
+      # Returns spatial matches found in password using a single adjacency graph.
+      #
+      # @param graph [Hash] adjacency map for each key character
+      # @param graph_name [String] name of the graph (e.g. "qwerty")
+      # @param password [String]
+      # @return [Array<Match>] matches with pattern "spatial"
       def matches_for_graph(graph, graph_name, password)
         result = []
         keyboard_graph = %w[qwerty dvorak].include?(graph_name)

--- a/lib/zxcvbn/matchers/year.rb
+++ b/lib/zxcvbn/matchers/year.rb
@@ -4,11 +4,15 @@ require 'zxcvbn/matchers/regex_helpers'
 
 module Zxcvbn
   module Matchers
+    # Matches 4-digit year substrings (1900–2050) in the password.
     class Year
       include RegexHelpers
 
+      # Matches years from 1900 to 2050.
       YEAR_REGEX = /19\d\d|20[0-4]\d|2050/
 
+      # @param password [String]
+      # @return [Array<Match>] matches with pattern "year"
       def matches(password)
         result = []
         re_match_all(YEAR_REGEX, password) do |match|

--- a/lib/zxcvbn/math.rb
+++ b/lib/zxcvbn/math.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  # Mathematical utilities used by the guess estimation logic.
   module Math
+    # Estimates the brute-force cardinality of the character set used in password.
+    #
+    # @param password [String] the password being evaluated
+    # @return [Integer] size of the character space (digits + upper + lower + symbols)
     def bruteforce_cardinality(password)
       is_type_of = {}
 
@@ -26,10 +31,19 @@ module Zxcvbn
       cardinality
     end
 
+    # Computes log base 2 of n.
+    #
+    # @param n [Numeric]
+    # @return [Float]
     def lg(n)
       ::Math.log(n, 2)
     end
 
+    # Computes the binomial coefficient C(n, k) ("n choose k").
+    #
+    # @param n [Integer]
+    # @param k [Integer]
+    # @return [Integer]
     def nCk(n, k)
       return 0 if k > n
       return 1 if k.zero?
@@ -47,10 +61,18 @@ module Zxcvbn
       r
     end
 
+    # Returns the precomputed average key-adjacency degree for a keyboard graph.
+    #
+    # @param graph_name [String] e.g. "qwerty" or "keypad"
+    # @return [Float]
     def average_degree_for_graph(graph_name)
       data.graph_stats[graph_name][:average_degree]
     end
 
+    # Returns the number of starting positions (keys) in a keyboard graph.
+    #
+    # @param graph_name [String] e.g. "qwerty" or "keypad"
+    # @return [Integer]
     def starting_positions_for_graph(graph_name)
       data.graph_stats[graph_name][:starting_positions]
     end

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -11,12 +11,23 @@ require 'zxcvbn/matchers/year'
 require 'zxcvbn/matchers/date'
 
 module Zxcvbn
+  # Runs all registered matchers against a password and aggregates results.
+  #
+  # Includes dictionary, l33t, spatial, digit, repeat, sequence, year, date,
+  # and reverse-dictionary matchers. User-supplied word lists are wrapped in
+  # transient matchers for each call to {#matches}.
   class Omnimatch
+    # @param data [Data] loaded frequency lists and adjacency graphs
     def initialize(data)
       @data = data
       @matchers = build_matchers
     end
 
+    # Returns all matches found in the password across every registered matcher.
+    #
+    # @param password [String] the password to analyse
+    # @param user_inputs [Array<String>] caller-supplied words to add as a dictionary
+    # @return [Array<Match>]
     def matches(password, user_inputs = [])
       matchers = @matchers + user_input_matchers(user_inputs)
       all_matches = matchers.map { |matcher| matcher.matches(password) }.inject(&:+)

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -6,14 +6,25 @@ require 'zxcvbn/omnimatch'
 require 'zxcvbn/scorer'
 
 module Zxcvbn
+  # Analyses a single password and returns a {Score}.
+  #
+  # Passwords longer than {MAX_PASSWORD_LENGTH} are silently truncated before
+  # analysis.
   class PasswordStrength
+    # Passwords longer than this are truncated before analysis.
     MAX_PASSWORD_LENGTH = 256
 
+    # @param data [Data] loaded frequency lists and adjacency graphs
     def initialize(data)
       @omnimatch = Omnimatch.new(data)
       @scorer = Scorer.new(data)
     end
 
+    # Analyses password strength and returns a populated {Score}.
+    #
+    # @param password [String] the password to evaluate (truncated to {MAX_PASSWORD_LENGTH})
+    # @param user_inputs [Array<String>] caller-supplied words to treat as known dictionary entries
+    # @return [Score]
     def test(password, user_inputs = [])
       password = (password || '').slice(0, MAX_PASSWORD_LENGTH)
       result = nil

--- a/lib/zxcvbn/score.rb
+++ b/lib/zxcvbn/score.rb
@@ -1,14 +1,40 @@
 # frozen_string_literal: true
 
 module Zxcvbn
+  # The result of analysing a password — returned by {Zxcvbn.test}.
+  #
+  # @!attribute [rw] guesses
+  #   @return [Integer] estimated number of guesses to crack the password
+  # @!attribute [rw] crack_times_seconds
+  #   @return [Hash{String => Float}] crack time in seconds per attack scenario
+  # @!attribute [rw] crack_times_display
+  #   @return [Hash{String => String}] human-readable crack times per scenario
+  # @!attribute [rw] score
+  #   @return [Integer] 0–4 score (0 = very weak, 4 = very strong)
+  # @!attribute [rw] sequence
+  #   @return [Array<Match>] the optimal match sequence
+  # @!attribute [rw] password
+  #   @return [String] the password that was evaluated
+  # @!attribute [rw] calc_time
+  #   @return [Float] time taken to evaluate, in seconds
+  # @!attribute [rw] feedback
+  #   @return [Feedback] human-readable feedback for low-scoring passwords
   class Score
     attr_accessor :guesses, :crack_times_seconds, :crack_times_display, :score,
                   :sequence, :password, :calc_time, :feedback
 
+    # @return [Float, nil] log10 of {#guesses}, or nil if guesses is not set
     def guesses_log10
       ::Math.log10(@guesses) if @guesses
     end
 
+    # @param options [Hash]
+    # @option options [Integer] :guesses
+    # @option options [Hash] :crack_times_seconds
+    # @option options [Hash] :crack_times_display
+    # @option options [Integer] :score
+    # @option options [Array<Match>] :sequence
+    # @option options [String] :password
     def initialize(options = {})
       @guesses             = options[:guesses]
       @crack_times_seconds = options[:crack_times_seconds]

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -22,14 +22,24 @@ module Zxcvbn
       @data = Data.new
     end
 
+    # Evaluates a password and returns a {Score}.
+    #
+    # @param password [String] the password to evaluate
+    # @param user_inputs [Array<String>] caller-supplied words to treat as known
+    # @return [Score]
     def test(password, user_inputs = [])
       PasswordStrength.new(@data).test(password, sanitize(user_inputs))
     end
 
+    # Adds custom word lists to the loaded data for all future {#test} calls.
+    #
+    # @param lists [Hash{String => Array<String>}] named word lists
+    # @return [void]
     def add_word_lists(lists)
       lists.each_pair { |name, words| @data.add_word_list(name, sanitize(words)) }
     end
 
+    # @return [String] a concise representation that omits the large dictionary data
     def inspect
       "#<#{self.class}:0x#{__id__.to_s(16)}>"
     end


### PR DESCRIPTION
## Context

The public API has partial YARD documentation. Several classes, modules, methods, and constants across `lib/` are undocumented, leaving gaps in tooling such as rubydoc.info and IDE integrations.

## Changes

- Adds YARD doc comments to every undocumented public class, module, method, and constant across `lib/`
- Uses `@!attribute` macros on `Match`, `Score`, and `Feedback` to document their dynamic attributes
- Adds a changelog entry under `Added`

## Consequences

`yard stats` reports 100% coverage with no warnings.