### PR TITLE
Optimise test suite: cache shared Data and Tester instances

### DIFF
--- a/spec/matchers/dictionary_spec.rb
+++ b/spec/matchers/dictionary_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Zxcvbn::Matchers::Dictionary do
     context 'Given a dictionary of English words' do
       subject(:matcher) { described_class.new('Test dictionary', dictionary) }
 
-      let(:dictionary) { Zxcvbn::Data.new.ranked_dictionaries['english'] }
+      let(:dictionary) { ZXCVBN_TEST_DATA.ranked_dictionaries['english'] }
       let(:password) { 'whatisinit' }
 
       it 'finds all the matches' do

--- a/spec/matchers/spatial_spec.rb
+++ b/spec/matchers/spatial_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Zxcvbn::Matchers::Spatial do
   let(:matcher) { Zxcvbn::Matchers::Spatial.new(graphs) }
-  let(:graphs)  { Zxcvbn::Data.new.adjacency_graphs }
+  let(:graphs)  { ZXCVBN_TEST_DATA.adjacency_graphs }
 
   describe '#matches' do
     let(:matches) { matcher.matches('rtyikm') }

--- a/spec/omnimatch_spec.rb
+++ b/spec/omnimatch_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Zxcvbn::Omnimatch do
-  let(:data) { Zxcvbn::Data.new }
+  let(:data) { ZXCVBN_TEST_DATA }
   let(:omnimatch) { described_class.new(data) }
 
   describe 'forward matching' do

--- a/spec/scoring/math_spec.rb
+++ b/spec/scoring/math_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Zxcvbn::Math do
   include Zxcvbn::Math
 
   def data
-    Zxcvbn::Data.new
+    ZXCVBN_TEST_DATA
   end
 
   describe '#bruteforce_cardinality' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require 'zxcvbn'
 
 Dir[Pathname.new(File.expand_path(__dir__)).join('support/**/*.rb')].each { |f| require f }
 
+ZXCVBN_TEST_DATA = Zxcvbn::Data.new
+
 RSpec.configure do |config|
   config.include JsHelpers
 

--- a/spec/support/js_helpers.rb
+++ b/spec/support/js_helpers.rb
@@ -31,6 +31,6 @@ module JsHelpers
   end
 
   def js_zxcvbn(password)
-    run_js("zxcvbn('#{password}')")
+    run_js("zxcvbn(#{password.to_json})")
   end
 end

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -6,28 +6,33 @@ require 'benchmark'
 RSpec.describe Zxcvbn::Tester do
   let(:tester) { Zxcvbn::Tester.new }
 
-  TEST_PASSWORDS.each do |password|
-    it "matches the JS result for #{password}" do
-      ruby_result = tester.test(password)
-      js_result = js_zxcvbn(password)
+  context 'JS compatibility' do
+    before(:context) { @shared_tester = Zxcvbn::Tester.new }
+    let(:tester) { @shared_tester }
 
-      expect(ruby_result.calc_time).not_to be_nil
-      expect(ruby_result.password).to eq js_result['password']
-      expect(ruby_result.score).to eq js_result['score']
-      expect(ruby_result.sequence.count).to eq js_result['sequence'].count
+    TEST_PASSWORDS.each do |password|
+      it "matches the JS result for #{password}" do
+        ruby_result = tester.test(password)
+        js_result = js_zxcvbn(password)
 
-      expect(ruby_result.guesses_log10).to be_within(0.01).of(js_result['guesses_log10'])
+        expect(ruby_result.calc_time).not_to be_nil
+        expect(ruby_result.password).to eq js_result['password']
+        expect(ruby_result.score).to eq js_result['score']
+        expect(ruby_result.sequence.count).to eq js_result['sequence'].count
 
-      ruby_result.sequence.zip(js_result['sequence']).each_with_index do |(ruby_match, js_match), idx|
-        # Ruby uses 'year' where JS v4 uses 'regex' (regex_name: 'recent_year') — intentional naming difference.
-        ruby_pattern = ruby_match.pattern == 'year' ? 'regex' : ruby_match.pattern
-        expect(ruby_pattern).to eq(js_match['pattern']), "match #{idx} pattern mismatch"
-        expect(ruby_match.i).to eq(js_match['i']), "match #{idx} i mismatch"
-        expect(ruby_match.j).to eq(js_match['j']), "match #{idx} j mismatch"
+        expect(ruby_result.guesses_log10).to be_within(0.01).of(js_result['guesses_log10'])
+
+        ruby_result.sequence.zip(js_result['sequence']).each_with_index do |(ruby_match, js_match), idx|
+          # Ruby uses 'year' where JS v4 uses 'regex' (regex_name: 'recent_year') — intentional naming difference.
+          ruby_pattern = ruby_match.pattern == 'year' ? 'regex' : ruby_match.pattern
+          expect(ruby_pattern).to eq(js_match['pattern']), "match #{idx} pattern mismatch"
+          expect(ruby_match.i).to eq(js_match['i']), "match #{idx} i mismatch"
+          expect(ruby_match.j).to eq(js_match['j']), "match #{idx} j mismatch"
+        end
+
+        expect(ruby_result.feedback.warning).to eq js_result['feedback']['warning']
+        expect(ruby_result.feedback.suggestions).to eq js_result['feedback']['suggestions']
       end
-
-      expect(ruby_result.feedback.warning).to eq js_result['feedback']['warning']
-      expect(ruby_result.feedback.suggestions).to eq js_result['feedback']['suggestions']
     end
   end
 


### PR DESCRIPTION
## Context

`Zxcvbn::Data.new` reads ~782 KB of frequency list files from disk, parses a JSON adjacency graph, ranks six dictionaries, and builds a trie for each. Several specs call `Data.new` (or `Tester.new`, which does so internally) inside `let` blocks, meaning a full initialisation occurs for every example. The 50-password JS compatibility loop in `tester_spec.rb` is the largest contributor, creating a fresh `Tester` (and therefore a fresh `Data`) for each password. The `js_zxcvbn` helper constructs its JS eval string via bare string interpolation, which would break on passwords containing single quotes. The full suite takes ~40 s to run.

## Changes

- Introduce `ZXCVBN_TEST_DATA = Zxcvbn::Data.new` in `spec_helper.rb`, initialised once at suite startup. Replace `Zxcvbn::Data.new` calls in `omnimatch_spec.rb`, `matchers/spatial_spec.rb`, `matchers/dictionary_spec.rb`, and `scoring/math_spec.rb` with references to this constant.
- Wrap the 50-password JS compatibility loop in its own context with a `before(:context)`-cached `Tester`. Contexts that mutate tester state via `add_word_lists` retain isolated instances via the outer `let(:tester)`.
- Fix `js_zxcvbn` to serialise the password with `to_json` instead of bare string interpolation.

## Consequences

- Suite runtime drops from ~40 s to ~24 s (~40% faster).
- Passwords containing single quotes or special characters will no longer break the JS eval.
- Tests that mutate `Data` state must continue to use their own instances — the shared constant must not be passed to `add_word_list`.