### PR TITLE
Modernise for Ruby 3.x: Data value object, pattern matching, L33t cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - YARD documentation for all public classes, modules, and methods ([#72])
 
 ### Changed
+ - `Zxcvbn::Score` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`calc_time=`, `feedback=`, etc.) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#74])
  - **Breaking**: Scoring algorithm aligned with zxcvbn.js v4.4.2. The dynamic programming step now minimises total guesses (`factorial(l) × cumulative_product + MIN_GUESSES^(l-1)` penalty) instead of entropy bits. Scores for many passwords will change ([#69])
  - **Breaking**: Bruteforce cardinality is now fixed at 10 (digits only), matching zxcvbn.js v4. Previously it was computed dynamically from the character classes present in the password (10–95), so bruteforce guesses for passwords containing letters or symbols will change ([#69])
  - **Breaking**: `Repeat` matcher now detects multi-character repeating units (e.g. `abcabc`). The `base_token` field holds the repeating unit (which may be more than one character); `repeated_char` has been removed ([#69])
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#69]: https://github.com/envato/zxcvbn-ruby/pull/69
 [#70]: https://github.com/envato/zxcvbn-ruby/pull/70
 [#72]: https://github.com/envato/zxcvbn-ruby/pull/72
+[#74]: https://github.com/envato/zxcvbn-ruby/pull/74
 
 ## [1.4.0] - 2026-01-15
 

--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -45,14 +45,14 @@ module Zxcvbn
 
       guesses =
         case match.pattern
-        when 'bruteforce' then bruteforce_guesses(match)
-        when 'dictionary' then dictionary_guesses(match)
-        when 'spatial'    then spatial_guesses(match)
-        when 'repeat'     then repeat_guesses(match, user_inputs:)
-        when 'sequence'   then sequence_guesses(match)
-        when 'digits'     then digits_guesses(match)
-        when 'year'       then year_guesses(match)
-        when 'date'       then date_guesses(match)
+        in 'bruteforce' then bruteforce_guesses(match)
+        in 'dictionary' then dictionary_guesses(match)
+        in 'spatial'    then spatial_guesses(match)
+        in 'repeat'     then repeat_guesses(match, user_inputs:)
+        in 'sequence'   then sequence_guesses(match)
+        in 'digits'     then digits_guesses(match)
+        in 'year'       then year_guesses(match)
+        in 'date'       then date_guesses(match)
         else 1
         end
 

--- a/lib/zxcvbn/matchers/l33t.rb
+++ b/lib/zxcvbn/matchers/l33t.rb
@@ -56,11 +56,7 @@ module Zxcvbn
       # @param sub [Hash{String => String}] character substitution map
       # @return [String]
       def translate(password, sub)
-        result = String.new
-        password.each_char do |chr|
-          result << (sub[chr] || chr)
-        end
-        result
+        password.gsub(Regexp.union(sub.keys), sub)
       end
 
       # Returns the subset of {L33T_TABLE} whose l33t characters appear in password.
@@ -84,15 +80,7 @@ module Zxcvbn
         keys = table.keys
         subs = [[]]
         subs = find_substitutions(subs, table, keys)
-        new_subs = []
-        subs.each do |sub|
-          hash = {}
-          sub.each do |l33t_char, chr|
-            hash[l33t_char] = chr
-          end
-          new_subs << hash
-        end
-        new_subs
+        subs.map(&:to_h)
       end
 
       private
@@ -123,17 +111,10 @@ module Zxcvbn
         next_subs = []
         table[first_key].each do |l33t_char|
           subs.each do |sub|
-            dup_l33t_index = -1
-            (0...sub.length).each do |i|
-              if sub[i][0] == l33t_char
-                dup_l33t_index = i
-                break
-              end
-            end
+            dup_l33t_index = sub.find_index { |pair| pair[0] == l33t_char }
 
-            if dup_l33t_index == -1
-              sub_extension = sub + [[l33t_char, first_key]]
-              next_subs << sub_extension
+            if dup_l33t_index.nil?
+              next_subs << sub + [[l33t_char, first_key]]
             else
               sub_alternative = sub.dup
               sub_alternative[dup_l33t_index, 1] = [[l33t_char, first_key]]

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -32,9 +32,10 @@ module Zxcvbn
         matches = @omnimatch.matches(password, user_inputs)
         result = @scorer.most_guessable_match_sequence(password, matches, user_inputs:)
       end
-      result.calc_time = calc_time
-      result.feedback = FeedbackGiver.get_feedback(result.score, result.sequence)
-      result
+      result.with(
+        calc_time:,
+        feedback: FeedbackGiver.get_feedback(result.score, result.sequence)
+      )
     end
   end
 end

--- a/lib/zxcvbn/score.rb
+++ b/lib/zxcvbn/score.rb
@@ -3,45 +3,33 @@
 module Zxcvbn
   # The result of analysing a password — returned by {Zxcvbn.test}.
   #
-  # @!attribute [rw] guesses
-  #   @return [Integer] estimated number of guesses to crack the password
-  # @!attribute [rw] crack_times_seconds
-  #   @return [Hash{String => Float}] crack time in seconds per attack scenario
-  # @!attribute [rw] crack_times_display
-  #   @return [Hash{String => String}] human-readable crack times per scenario
-  # @!attribute [rw] score
-  #   @return [Integer] 0–4 score (0 = very weak, 4 = very strong)
-  # @!attribute [rw] sequence
-  #   @return [Array<Match>] the optimal match sequence
-  # @!attribute [rw] password
+  # @!attribute [r] password
   #   @return [String] the password that was evaluated
-  # @!attribute [rw] calc_time
-  #   @return [Float] time taken to evaluate, in seconds
-  # @!attribute [rw] feedback
-  #   @return [Feedback] human-readable feedback for low-scoring passwords
-  class Score
-    attr_accessor :guesses, :crack_times_seconds, :crack_times_display, :score,
-                  :sequence, :password, :calc_time, :feedback
+  # @!attribute [r] guesses
+  #   @return [Integer] estimated number of guesses to crack the password
+  # @!attribute [r] sequence
+  #   @return [Array<Match>] the optimal match sequence
+  # @!attribute [r] crack_times_seconds
+  #   @return [Hash{String => Float}] crack time in seconds per attack scenario
+  # @!attribute [r] crack_times_display
+  #   @return [Hash{String => String}] human-readable crack times per scenario
+  # @!attribute [r] score
+  #   @return [Integer] 0–4 score (0 = very weak, 4 = very strong)
+  # @!attribute [r] calc_time
+  #   @return [Float, nil] time taken to evaluate, in seconds
+  # @!attribute [r] feedback
+  #   @return [Feedback, nil] human-readable feedback for low-scoring passwords
+  Score = ::Data.define(
+    :password, :guesses, :sequence, :crack_times_seconds,
+    :crack_times_display, :score, :calc_time, :feedback
+  ) do
+    def initialize(calc_time: nil, feedback: nil, **kwargs)
+      super(calc_time:, feedback:, **kwargs)
+    end
 
     # @return [Float, nil] log10 of {#guesses}, or nil if guesses is not set
     def guesses_log10
-      ::Math.log10(@guesses) if @guesses
-    end
-
-    # @param options [Hash]
-    # @option options [Integer] :guesses
-    # @option options [Hash] :crack_times_seconds
-    # @option options [Hash] :crack_times_display
-    # @option options [Integer] :score
-    # @option options [Array<Match>] :sequence
-    # @option options [String] :password
-    def initialize(options = {})
-      @guesses             = options[:guesses]
-      @crack_times_seconds = options[:crack_times_seconds]
-      @crack_times_display = options[:crack_times_display]
-      @score               = options[:score]
-      @sequence            = options[:sequence]
-      @password            = options[:password]
+      ::Math.log10(guesses) if guesses
     end
   end
 end

--- a/sig/zxcvbn/score.rbs
+++ b/sig/zxcvbn/score.rbs
@@ -1,15 +1,26 @@
 module Zxcvbn
-  class Score
-    attr_accessor guesses: Numeric?
-    def guesses_log10: () -> Float?
-    attr_accessor crack_times_seconds: Hash[String, Float]?
-    attr_accessor crack_times_display: Hash[String, String]?
-    attr_accessor score: Integer?
-    attr_accessor sequence: Array[Match]?
-    attr_accessor password: String?
-    attr_accessor calc_time: Float?
-    attr_accessor feedback: Feedback?
+  class Score < ::Data
+    def self.new: (
+      password: String,
+      guesses: Numeric,
+      sequence: Array[Match],
+      crack_times_seconds: Hash[String, Float],
+      crack_times_display: Hash[String, String],
+      score: Integer,
+      ?calc_time: Float?,
+      ?feedback: Feedback?
+    ) -> instance
 
-    def initialize: (?Hash[Symbol, untyped] options) -> void
+    attr_reader password: String?
+    attr_reader guesses: Numeric?
+    attr_reader sequence: Array[Match]?
+    attr_reader crack_times_seconds: Hash[String, Float]?
+    attr_reader crack_times_display: Hash[String, String]?
+    attr_reader score: Integer?
+    attr_reader calc_time: Float?
+    attr_reader feedback: Feedback?
+
+    def guesses_log10: () -> Float?
+    def with: (**untyped) -> instance
   end
 end


### PR DESCRIPTION
## Context

The minimum Ruby version was recently raised to 3.3, opening up features from Ruby 3.0–3.2 that weren't previously available. `Score` is a plain class with `attr_accessor` on all fields and a hash-options `initialize`. `L33t` builds substitution hashes and translates characters using manual loops. `estimate_guesses` dispatches by pattern name using `case/when`.

## Changes

- Convert `Zxcvbn::Score` to `::Data.define` (Ruby 3.2). `initialize` provides `nil` defaults for `calc_time` and `feedback`; `PasswordStrength#test` uses `Data#with` to attach both after timing. RBS updated to reflect read-only members and `with`.
- Switch `case/when` to `case/in` pattern matching in `Guesses#estimate_guesses`.
- Simplify `L33t`: replace the `each_char` translation loop with `gsub(Regexp.union(keys), hash)`, collapse the pair-array-to-hash loop in `l33t_subs` to `map(&:to_h)`, and use `find_index` in `find_substitutions` instead of a manual sentinel loop.

## Consequences

`Score` instances are now immutable — attribute setters (`calc_time=`, `feedback=`, etc.) no longer exist. Instances gain structural equality (`==`/`eql?`/`hash`) and `with`. Any code that mutated a `Score` after receiving it from `Zxcvbn.test` will break.