### PR TITLE
Remove dead `Math#bruteforce_cardinality` and `Math#lg`

### DIFF
--- a/lib/zxcvbn/math.rb
+++ b/lib/zxcvbn/math.rb
@@ -2,43 +2,8 @@
 
 module Zxcvbn
   # Mathematical utilities used by the guess estimation logic.
+  # @api private
   module Math
-    # Estimates the brute-force cardinality of the character set used in password.
-    #
-    # @param password [String] the password being evaluated
-    # @return [Integer] size of the character space (digits + upper + lower + symbols)
-    def bruteforce_cardinality(password)
-      is_type_of = {}
-
-      password.each_byte do |ordinal|
-        case ordinal
-        when (48..57)
-          is_type_of['digits'] = true
-        when (65..90)
-          is_type_of['upper'] = true
-        when (97..122)
-          is_type_of['lower'] = true
-        else
-          is_type_of['symbols'] = true
-        end
-      end
-
-      cardinality = 0
-      cardinality += 10 if is_type_of['digits']
-      cardinality += 26 if is_type_of['upper']
-      cardinality += 26 if is_type_of['lower']
-      cardinality += 33 if is_type_of['symbols']
-      cardinality
-    end
-
-    # Computes log base 2 of n.
-    #
-    # @param n [Numeric]
-    # @return [Float]
-    def lg(n)
-      ::Math.log(n, 2)
-    end
-
     # Computes the binomial coefficient C(n, k) ("n choose k").
     #
     # @param n [Integer]

--- a/sig/zxcvbn/math.rbs
+++ b/sig/zxcvbn/math.rbs
@@ -1,9 +1,5 @@
 module Zxcvbn
   module Math
-    def bruteforce_cardinality: (String password) -> Integer
-
-    def lg: (Numeric n) -> Float
-
     def nCk: (Integer n, Integer k) -> Integer
 
     def average_degree_for_graph: (String graph_name) -> Float

--- a/spec/scoring/math_spec.rb
+++ b/spec/scoring/math_spec.rb
@@ -9,80 +9,6 @@ RSpec.describe Zxcvbn::Math do
     ZXCVBN_TEST_DATA
   end
 
-  describe '#bruteforce_cardinality' do
-    context 'when empty password' do
-      it 'should return 0 if empty password' do
-        expect(bruteforce_cardinality('')).to eql 0
-      end
-    end
-
-    context 'when password is one character long' do
-      context 'and a digit' do
-        it 'should return 10' do
-          10.times do |digit|
-            expect(bruteforce_cardinality(digit.to_s)).to eql 10
-          end
-        end
-      end
-
-      context 'and an upper case character' do
-        it 'should return 26' do
-          ('A'..'Z').each do |character|
-            expect(bruteforce_cardinality(character)).to eql 26
-          end
-        end
-      end
-
-      context 'and a lower case character' do
-        it 'should return 26' do
-          ('a'..'z').each do |character|
-            expect(bruteforce_cardinality(character)).to eql 26
-          end
-        end
-      end
-
-      context 'and a symbol' do
-        it 'should return 33' do
-          %w|/ [ ` {|.each do |symbol|
-            expect(bruteforce_cardinality(symbol)).to eql 33
-          end
-        end
-      end
-    end
-
-    context 'when password is more than one character long' do
-      context 'and only digits' do
-        it 'should return 10' do
-          expect(bruteforce_cardinality('123456789')).to eql 10
-        end
-      end
-
-      context 'and only lowercase characters' do
-        it 'should return 26' do
-          expect(bruteforce_cardinality('password')).to eql 26
-        end
-      end
-
-      context 'and only uppercase characters' do
-        it 'should return 26' do
-          expect(bruteforce_cardinality('PASSWORD')).to eql 26
-        end
-      end
-
-      context 'and only symbols' do
-        it 'should return 33' do
-          expect(bruteforce_cardinality('/ [ ` {')).to eql 33
-        end
-      end
-
-      context 'and a mixed of character types' do
-        it 'should add up every character type cardinality' do
-          expect(bruteforce_cardinality('p1SsWorD!')).to eql 95
-        end
-      end
-    end
-  end
-
   describe '#average_degree_for_graph' do
     context 'when keyboard is qwerty' do
       it 'returns the correct average degree over all keys' do
@@ -132,27 +58,6 @@ RSpec.describe Zxcvbn::Math do
       it 'returns the correct average degree over all keys' do
         expect(starting_positions_for_graph('mac_keypad')).to eql 16
       end
-    end
-  end
-
-  describe '#lg' do
-    it 'calculates log base 2 correctly' do
-      expect(lg(1)).to eq 0.0
-      expect(lg(2)).to eq 1.0
-      expect(lg(4)).to eq 2.0
-      expect(lg(8)).to eq 3.0
-      expect(lg(16)).to eq 4.0
-    end
-
-    it 'handles non-power-of-2 values' do
-      expect(lg(3)).to be_within(0.0001).of(1.5849625)
-      expect(lg(10)).to be_within(0.0001).of(3.3219281)
-      expect(lg(100)).to be_within(0.0001).of(6.6438562)
-    end
-
-    it 'handles decimal values' do
-      expect(lg(0.5)).to eq(-1.0)
-      expect(lg(0.25)).to eq(-2.0)
     end
   end
 


### PR DESCRIPTION
## Context

`Zxcvbn::Math` includes two methods that are no longer called by anything in the library: `bruteforce_cardinality` and `lg`. Both were used by the old `entropy.rb` scoring logic, which was deleted when the v4 guesses-based algorithm was introduced. Bruteforce cardinality is now a fixed constant (`BRUTEFORCE_CARDINALITY = 10` in `Guesses`), matching zxcvbn.js v4.

## Changes

- Remove `Math#bruteforce_cardinality` and `Math#lg` from `lib/zxcvbn/math.rb`
- Remove their type signatures from `sig/zxcvbn/math.rbs`
- Remove their specs from `spec/scoring/math_spec.rb`
- Mark `Zxcvbn::Math` as `@api private` in YARD

## Consequences

`Zxcvbn::Math` no longer exposes these two methods. Any consumer calling them directly would get a `NoMethodError`, but no realistic consumer was doing so — they only made sense as helpers for the old entropy-based scoring. The module is now marked `@api private` to make that clear going forward.