### PR TITLE
Convert Feedback to Data, making it an immutable value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - `Zxcvbn::Score` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`calc_time=`, `feedback=`, etc.) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#74])
+ - **Breaking**: `Zxcvbn::Feedback` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`warning=`, `suggestions=`) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#77])
  - **Breaking**: Scoring algorithm aligned with zxcvbn.js v4.4.2. The dynamic programming step now minimises total guesses (`factorial(l) × cumulative_product + MIN_GUESSES^(l-1)` penalty) instead of entropy bits. Scores for many passwords will change ([#69])
  - **Breaking**: Bruteforce cardinality is now fixed at 10 (digits only), matching zxcvbn.js v4. Previously it was computed dynamically from the character classes present in the password (10–95), so bruteforce guesses for passwords containing letters or symbols will change ([#69])
  - **Breaking**: `Repeat` matcher now detects multi-character repeating units (e.g. `abcabc`). The `base_token` field holds the repeating unit (which may be more than one character); `repeated_char` has been removed ([#69])
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#70]: https://github.com/envato/zxcvbn-ruby/pull/70
 [#72]: https://github.com/envato/zxcvbn-ruby/pull/72
 [#74]: https://github.com/envato/zxcvbn-ruby/pull/74
+[#77]: https://github.com/envato/zxcvbn-ruby/pull/77
 
 ## [1.4.0] - 2026-01-15
 

--- a/README.md
+++ b/README.md
@@ -32,27 +32,11 @@ $ irb
 >> require 'zxcvbn'
 => true
 >> pp Zxcvbn.test('@lfred2004', ['alfred'])
-#<Zxcvbn::Score:0x00007f7f590610c8
- @calc_time=0.0007179999956861138,
- @crack_times_display=
-  {"online_throttling_100_per_hour"=>"instant",
-   "online_no_throttling_10_per_second"=>"instant",
-   "offline_slow_hashing_1e4_per_second"=>"instant",
-   "offline_fast_hashing_1e10_per_second"=>"instant"},
- @crack_times_seconds=
-  {"online_throttling_100_per_hour"=>540000.0,
-   "online_no_throttling_10_per_second"=>1500.0,
-   "offline_slow_hashing_1e4_per_second"=>1.5,
-   "offline_fast_hashing_1e10_per_second"=>1.5e-06},
- @feedback=
-  #<Zxcvbn::Feedback:0x00007f7f59060150
-   @suggestions=
-    ["Add another word or two. Uncommon words are better.",
-     "Predictable substitutions like '@' instead of 'a' don't help very much"],
-   @warning=nil>,
- @guesses=15000,
- @sequence=
-  [#<Zxcvbn::Match:0x00007f7f59060200
+#<data Zxcvbn::Score
+ password="@lfred2004",
+ guesses=15000.0,
+ sequence=
+  [#<Zxcvbn::Match:0x00000001139ddac8
     @base_guesses=1,
     @dictionary_name="user_inputs",
     @guesses=50,
@@ -68,36 +52,37 @@ $ irb
     @sub_display="@ -> a",
     @token="@lfred",
     @uppercase_variations=1>,
-   #<Zxcvbn::Match:0x00007f7f59060300
+   #<Zxcvbn::Match:0x00000001139de248
     @guesses=50,
     @guesses_log10=1.6989700043360187,
     @i=6,
     @j=9,
     @pattern="year",
     @token="2004">],
- @password="@lfred2004",
- @score=1>
-=> #<Zxcvbn::Score:0x00007f7f590610c8>
+ crack_times_seconds=
+  {"online_throttling_100_per_hour" => 540000.0,
+   "online_no_throttling_10_per_second" => 1500.0,
+   "offline_slow_hashing_1e4_per_second" => 1.5,
+   "offline_fast_hashing_1e10_per_second" => 1.5e-06},
+ crack_times_display=
+  {"online_throttling_100_per_hour" => "8 days",
+   "online_no_throttling_10_per_second" => "26 minutes",
+   "offline_slow_hashing_1e4_per_second" => "instant",
+   "offline_fast_hashing_1e10_per_second" => "instant"},
+ score=1,
+ calc_time=0.0009260000078938901,
+ feedback=
+  #<data Zxcvbn::Feedback
+   warning="",
+   suggestions=
+    ["Add another word or two. Uncommon words are better.",
+     "Predictable substitutions like '@' instead of 'a' don't help very much"]>>
 >> pp Zxcvbn.test('asdfghju7654rewq', ['alfred'])
-#<Zxcvbn::Score:0x00007f7f5a9e9248
- @calc_time=0.0011630000080913305,
- @crack_times_display=
-  {"online_throttling_100_per_hour"=>"centuries",
-   "online_no_throttling_10_per_second"=>"3 years",
-   "offline_slow_hashing_1e4_per_second"=>"2 hours",
-   "offline_fast_hashing_1e10_per_second"=>"instant"},
- @crack_times_seconds=
-  {"online_throttling_100_per_hour"=>3.323480495195046e+10,
-   "online_no_throttling_10_per_second"=>92318902.64430684,
-   "offline_slow_hashing_1e4_per_second"=>92318.90264430684,
-   "offline_fast_hashing_1e10_per_second"=>0.09231890264430684},
- @feedback=
-  #<Zxcvbn::Feedback:0x00007f7f5a9e9130
-   @suggestions=[],
-   @warning=nil>,
- @guesses=923189026.4430684,
- @sequence=
-  [#<Zxcvbn::Match:0x00007f7f5a9e9000
+#<data Zxcvbn::Score
+ password="asdfghju7654rewq",
+ guesses=923189026.4430684,
+ sequence=
+  [#<Zxcvbn::Match:0x00000001276dde90
     @graph="qwerty",
     @guesses=923189025.4430684,
     @guesses_log10=8.965290633097352,
@@ -107,9 +92,19 @@ $ irb
     @shifted_count=0,
     @token="asdfghju7654rewq",
     @turns=5>],
- @password="asdfghju7654rewq",
- @score=3>
-=> #<Zxcvbn::Score:0x00007f7f5a9e9248>
+ crack_times_seconds=
+  {"online_throttling_100_per_hour" => 33234804951.950462,
+   "online_no_throttling_10_per_second" => 92318902.64430684,
+   "offline_slow_hashing_1e4_per_second" => 92318.90264430684,
+   "offline_fast_hashing_1e10_per_second" => 0.09231890264430684},
+ crack_times_display=
+  {"online_throttling_100_per_hour" => "centuries",
+   "online_no_throttling_10_per_second" => "4 years",
+   "offline_slow_hashing_1e4_per_second" => "3 days",
+   "offline_fast_hashing_1e10_per_second" => "instant"},
+ score=3,
+ calc_time=0.001476000004913658,
+ feedback=#<data Zxcvbn::Feedback warning="" suggestions=[]>>
 ```
 
 ## Testing Multiple Passwords
@@ -123,27 +118,11 @@ $ irb
 >> tester = Zxcvbn::Tester.new
 => #<Zxcvbn::Tester:0x3fe99d869aa4>
 >> pp tester.test('@lfred2004', ['alfred'])
-#<Zxcvbn::Score:0x00007f7f586fcf50
- @calc_time=0.006318999978248030,
- @crack_times_display=
-  {"online_throttling_100_per_hour"=>"instant",
-   "online_no_throttling_10_per_second"=>"instant",
-   "offline_slow_hashing_1e4_per_second"=>"instant",
-   "offline_fast_hashing_1e10_per_second"=>"instant"},
- @crack_times_seconds=
-  {"online_throttling_100_per_hour"=>540000.0,
-   "online_no_throttling_10_per_second"=>1500.0,
-   "offline_slow_hashing_1e4_per_second"=>1.5,
-   "offline_fast_hashing_1e10_per_second"=>1.5e-06},
- @feedback=
-  #<Zxcvbn::Feedback:0x00007f7f586fcac8
-   @suggestions=
-    ["Add another word or two. Uncommon words are better.",
-     "Predictable substitutions like '@' instead of 'a' don't help very much"],
-   @warning=nil>,
- @guesses=15000,
- @sequence=
-  [#<Zxcvbn::Match:0x00007f7f586fc900
+#<data Zxcvbn::Score
+ password="@lfred2004",
+ guesses=15000.0,
+ sequence=
+  [#<Zxcvbn::Match:0x0000000126f7dcb8
     @base_guesses=1,
     @dictionary_name="user_inputs",
     @guesses=50,
@@ -159,23 +138,38 @@ $ irb
     @sub_display="@ -> a",
     @token="@lfred",
     @uppercase_variations=1>,
-   #<Zxcvbn::Match:0x00007f7f586fc800
+   #<Zxcvbn::Match:0x0000000126f7e438
     @guesses=50,
     @guesses_log10=1.6989700043360187,
     @i=6,
     @j=9,
     @pattern="year",
     @token="2004">],
- @password="@lfred2004",
- @score=1>
-=> #<Zxcvbn::Score:0x00007f7f586fcf50>
+ crack_times_seconds=
+  {"online_throttling_100_per_hour" => 540000.0,
+   "online_no_throttling_10_per_second" => 1500.0,
+   "offline_slow_hashing_1e4_per_second" => 1.5,
+   "offline_fast_hashing_1e10_per_second" => 1.5e-06},
+ crack_times_display=
+  {"online_throttling_100_per_hour" => "8 days",
+   "online_no_throttling_10_per_second" => "26 minutes",
+   "offline_slow_hashing_1e4_per_second" => "instant",
+   "offline_fast_hashing_1e10_per_second" => "instant"},
+ score=1,
+ calc_time=0.0010020000045187771,
+ feedback=
+  #<data Zxcvbn::Feedback
+   warning="",
+   suggestions=
+    ["Add another word or two. Uncommon words are better.",
+     "Predictable substitutions like '@' instead of 'a' don't help very much"]>>
 ```
 
-Subsequent calls reuse the already-loaded dictionaries, so `@calc_time` is significantly lower:
+Subsequent calls reuse the already-loaded dictionaries, so `calc_time` is significantly lower:
 
 ```ruby
 >> tester.test('@lfred2004', ['alfred']).calc_time
-=> 0.0009840000000596046
+=> 0.0006769999745301902
 ```
 
 > [!NOTE]

--- a/lib/zxcvbn/feedback.rb
+++ b/lib/zxcvbn/feedback.rb
@@ -3,19 +3,15 @@
 module Zxcvbn
   # Human-readable feedback for a low-scoring password.
   #
-  # @!attribute [rw] warning
+  # @!attribute [r] warning
   #   @return [String] a single warning message, or empty string
-  # @!attribute [rw] suggestions
+  # @!attribute [r] suggestions
   #   @return [Array<String>] ordered list of improvement tips
-  class Feedback
-    attr_accessor :warning, :suggestions
-
-    # @param options [Hash]
-    # @option options [String] :warning warning message (default: empty string)
-    # @option options [Array<String>] :suggestions improvement tips (default: [])
-    def initialize(options = {})
-      @warning     = options[:warning] || ''
-      @suggestions = options[:suggestions] || []
+  Feedback = ::Data.define(:warning, :suggestions) do
+    # @param warning [String] warning message (default: empty string)
+    # @param suggestions [Array<String>] improvement tips (default: [])
+    def initialize(warning: nil, suggestions: [])
+      super(warning: warning || '', suggestions:)
     end
   end
 end

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -13,9 +13,9 @@ module Zxcvbn
         'Use a few words, avoid common phrases',
         'No need for symbols, digits, or uppercase letters'
       ]
-    ).freeze
+    )
 
-    EMPTY_FEEDBACK = Feedback.new.freeze
+    EMPTY_FEEDBACK = Feedback.new
 
     # Returns feedback appropriate for the given score and match sequence.
     #
@@ -39,12 +39,10 @@ module Zxcvbn
       extra_feedback = 'Add another word or two. Uncommon words are better.'
 
       if feedback.nil?
-        feedback = Feedback.new(suggestions: [extra_feedback])
+        Feedback.new(suggestions: [extra_feedback])
       else
-        feedback.suggestions.unshift extra_feedback
+        feedback.with(suggestions: [extra_feedback, *feedback.suggestions])
       end
-
-      feedback
     end
 
     # Returns pattern-specific feedback for a single match, or nil if none applies.

--- a/sig/zxcvbn/feedback.rbs
+++ b/sig/zxcvbn/feedback.rbs
@@ -1,8 +1,8 @@
 module Zxcvbn
-  class Feedback
-    attr_accessor warning: String?
-    attr_accessor suggestions: Array[String]
+  class Feedback < Data
+    attr_reader warning: String
+    attr_reader suggestions: Array[String]
 
-    def initialize: (?warning: String?, ?suggestions: Array[String]) -> void
+    def initialize: (?warning: String, ?suggestions: Array[String]) -> void
   end
 end


### PR DESCRIPTION
## Context

`Zxcvbn::Score` was converted to `Data` in #74. `Zxcvbn::Feedback` is a natural companion — it is a small, pure value type with two fields and no internal state that needs mutation after construction.

## Changes

- `Zxcvbn::Feedback` is now defined with `::Data.define` (note `::Data` — inside the `Zxcvbn` module, bare `Data` resolves to `Zxcvbn::Data`, the gem's own data-loading class)
- Removed `.freeze` calls on `DEFAULT_FEEDBACK` and `EMPTY_FEEDBACK` constants in `FeedbackGiver` — `Data` instances are frozen by default
- Replaced `feedback.suggestions.unshift(extra_feedback)` mutation in `FeedbackGiver#get_feedback` with `feedback.with(suggestions: [extra_feedback, *feedback.suggestions])`
- `initialize` override coerces explicit `nil` warnings to `''` — `FeedbackGiver#get_dictionary_match_feedback` passes `warning: nil` when no warning condition is met, and `Data` keyword defaults only apply when the keyword is omitted entirely
- Updated RBS signature (`class Feedback < Data`, `attr_reader` only)
- Updated README to show the new `#<data Zxcvbn::Feedback ...>` inspect format

## Consequences

**Breaking**: attribute setters `warning=` and `suggestions=` are removed. Code that mutates a `Feedback` instance after construction must switch to `feedback.with(...)`.

Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies.