### PR TITLE
Remove 256-char password length cap and fix Float overflow for long passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Repeat feedback now distinguishes single-char repeats (`"aaa"`) from multi-char repeats (`"abcabcabc"`), matching zxcvbn.js v4 ([#69])
  - `year` pattern matches now produce a "Recent years are easy to guess" warning ([#69])
  - Sole matches from the `english_wikipedia` dictionary now produce an "A word by itself is easy to guess" warning ([#69])
- - Passwords longer than 256 characters are silently truncated before scoring to bound O(n²) dictionary matching time ([#69])
 
 ### Removed
  - Support for Ruby versions below 3.3 ([#70])

--- a/README.md
+++ b/README.md
@@ -172,7 +172,14 @@ Subsequent calls reuse the already-loaded dictionaries, so `calc_time` is signif
 => 0.0006769999745301902
 ```
 
-> [!NOTE]
+> [!WARNING]
+> Scoring time grows with password length. For adversarial inputs such as
+> short repeated sequences (e.g. `"ab" * 500`), the internal pattern-matching
+> DP produces super-quadratic runtime. Enforce a password length limit
+> appropriate for your use case before calling `Zxcvbn.test` or
+> `Zxcvbn::Tester#test`.
+
+> [!WARNING]
 > Storing the guesses or score for an encrypted or hashed value provides
 > information that can make cracking the value orders of magnitude easier for an
 > attacker. For this reason we advise you not to store the results of

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -14,7 +14,13 @@ module Zxcvbn
 
   DATA_PATH = Pathname(File.expand_path('../data', __dir__))
 
-  # Returns a Zxcvbn::Score for the given password
+  # Returns a Zxcvbn::Score for the given password.
+  #
+  # Scoring time grows with password length: the DP is O(n × m) where n is
+  # the password length and m is the number of pattern matches. For
+  # adversarial inputs such as short repeated sequences (e.g. "ab" * 500),
+  # m also grows with n, producing super-quadratic runtime. Enforce a
+  # password length limit appropriate for your use case before calling this.
   #
   # Example:
   #

--- a/lib/zxcvbn/crack_time.rb
+++ b/lib/zxcvbn/crack_time.rb
@@ -18,7 +18,7 @@ module Zxcvbn
     # @param guesses [Numeric] estimated guess count
     # @return [Hash] with :crack_times_seconds and :crack_times_display
     def estimate_attack_times(guesses)
-      seconds = ATTACK_SCENARIOS.transform_values { |rate| guesses / rate }
+      seconds = ATTACK_SCENARIOS.transform_values { |rate| [guesses / rate, Float::MAX].min }
       display = seconds.transform_values { |s| display_time(s) }
       { crack_times_seconds: seconds, crack_times_display: display }
     end

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -56,11 +56,12 @@ module Zxcvbn
         get_dictionary_match_feedback match, is_sole_match
 
       when 'spatial'
-        warning = if match.turns == 1
-                    'Straight rows of keys are easy to guess'
-                  else
-                    'Short keyboard patterns are easy to guess'
-                  end
+        warning =
+          if match.turns == 1
+            'Straight rows of keys are easy to guess'
+          else
+            'Short keyboard patterns are easy to guess'
+          end
 
         Feedback.new(
           warning:,

--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -62,10 +62,11 @@ module Zxcvbn
     end
 
     # @param match [Match] a bruteforce match
-    # @return [Integer] guesses based on token length and assumed cardinality
+    # @return [Float] guesses based on token length and assumed cardinality
     def bruteforce_guesses(match)
-      guesses = BRUTEFORCE_CARDINALITY**match.token.length
-      min = match.token.length == 1 ? MIN_SUBMATCH_GUESSES_SINGLE_CHAR + 1 : MIN_SUBMATCH_GUESSES_MULTI_CHAR + 1
+      guesses = BRUTEFORCE_CARDINALITY**match.token.length.to_f
+      guesses = Float::MAX if guesses.infinite?
+      min = match.token.length == 1 ? MIN_SUBMATCH_GUESSES_SINGLE_CHAR + 1.0 : MIN_SUBMATCH_GUESSES_MULTI_CHAR + 1.0
       [guesses, min].max
     end
 

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -7,13 +7,7 @@ require 'zxcvbn/scorer'
 
 module Zxcvbn
   # Analyses a single password and returns a {Score}.
-  #
-  # Passwords longer than {MAX_PASSWORD_LENGTH} are silently truncated before
-  # analysis.
   class PasswordStrength
-    # Passwords longer than this are truncated before analysis.
-    MAX_PASSWORD_LENGTH = 256
-
     # @param data [Data] loaded frequency lists and adjacency graphs
     def initialize(data)
       @omnimatch = Omnimatch.new(data)
@@ -22,11 +16,11 @@ module Zxcvbn
 
     # Analyses password strength and returns a populated {Score}.
     #
-    # @param password [String] the password to evaluate (truncated to {MAX_PASSWORD_LENGTH})
+    # @param password [String] the password to evaluate
     # @param user_inputs [Array<String>] caller-supplied words to treat as known dictionary entries
     # @return [Score]
     def test(password, user_inputs = [])
-      password = (password || '').slice(0, MAX_PASSWORD_LENGTH)
+      password ||= ''
       result = nil
       calc_time = Clock.realtime do
         matches = @omnimatch.matches(password, user_inputs)

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -13,20 +13,21 @@ module Zxcvbn
     include CrackTime
 
     # Hash{Integer => Float} — factorial lookup for the DP hot loop.
-    # Precomputed up to MAX_PASSWORD_LENGTH (256); the default proc extends on demand
-    # by multiplying from the last cached entry.
-    FACTORIAL = (0..256).each_with_object(Hash.new { |h, n| h[n] = h[n - 1] * n }) do |n, h|
+    # Keys must be non-negative integers. Precomputed to 170 (the last value
+    # before overflow); returns Float::MAX for any key > 170.
+    FACTORIAL = (0..170).each_with_object(Hash.new { Float::MAX }) do |n, h|
       h[n] = n < 2 ? 1.0 : h[n - 1] * n
-    end
+    end.freeze
 
     # Hash{Integer => Float} — powers of {MIN_GUESSES_BEFORE_GROWING_SEQUENCE} for the
-    # additive sequence-length penalty. Precomputed up to MAX_PASSWORD_LENGTH (256);
-    # the default proc extends on demand by multiplying from the last cached entry.
-    MIN_GUESSES_POW = (0..255).each_with_object(
-      Hash.new { |h, n| h[n] = h[n - 1] * MIN_GUESSES_BEFORE_GROWING_SEQUENCE }
-    ) do |n, h|
+    # additive sequence-length penalty. Keys must be non-negative integers.
+    # Precomputed to 77 (the last value before overflow); returns Float::MAX for
+    # any key > 77.
+    MIN_GUESSES_POW = (0..77).each_with_object(Hash.new { Float::MAX }) do |n, h|
       h[n] = MIN_GUESSES_BEFORE_GROWING_SEQUENCE.to_f**n
-    end
+    end.freeze
+
+    private_constant :FACTORIAL, :MIN_GUESSES_POW
 
     # @param data [Data] the loaded frequency list and graph data
     def initialize(data)

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -24,6 +24,12 @@ module Zxcvbn
 
     # Evaluates a password and returns a {Score}.
     #
+    # Scoring time grows with password length: the DP is O(n × m) where n is
+    # the password length and m is the number of pattern matches. For
+    # adversarial inputs such as short repeated sequences (e.g. "ab" * 500),
+    # m also grows with n, producing super-quadratic runtime. Enforce a
+    # password length limit appropriate for your use case before calling this.
+    #
     # @param password [String] the password to evaluate
     # @param user_inputs [Array<String>] caller-supplied words to treat as known
     # @return [Score]

--- a/spec/tester_spec.rb
+++ b/spec/tester_spec.rb
@@ -113,18 +113,28 @@ RSpec.describe Zxcvbn::Tester do
     end
   end
 
-  context 'with a password exceeding MAX_PASSWORD_LENGTH' do
-    let(:max) { Zxcvbn::PasswordStrength::MAX_PASSWORD_LENGTH }
-
-    it 'truncates the password before scoring' do
-      result = tester.test('a' * (max + 100))
-      expect(result.password.length).to eq max
+  context 'with a very long password' do
+    it 'scores the full password without truncation' do
+      long = 'a' * 400
+      result = tester.test(long)
+      expect(result.password.length).to eq 400
     end
 
     it 'completes in reasonable time for adversarial repeat inputs' do
-      adversarial = 'ab' * 150
+      adversarial = 'ab' * 128
       elapsed = Benchmark.realtime { tester.test(adversarial) }
       expect(elapsed).to be < 5
+    end
+
+    it 'produces finite crack times for passwords longer than 308 characters' do
+      # 'z' * 400 hits the repeat matcher (guesses ~4801), not bruteforce.
+      # Use a high-entropy string so the whole password is a single bruteforce
+      # match: length 400 → 10**400 → Float::MAX → crack time overflows to Infinity.
+      saved = srand(7)
+      high_entropy = (1..400).map { rand(33..126).chr }.join
+      srand(saved)
+      result = tester.test(high_entropy)
+      expect(result.crack_times_seconds.values).to all(be_finite)
     end
   end
 end


### PR DESCRIPTION
## Context

The DP scoring rewrite (#69) computes `BRUTEFORCE_CARDINALITY ** token_length` as an integer exponentiation. For token lengths ≥ 309, Ruby produces a Bignum that overflows to `Float::INFINITY` in downstream Float arithmetic, causing `crack_times_seconds` values to be `Infinity`. `FACTORIAL` and `MIN_GUESSES_POW` have auto-extending default procs that also overflow for large sequence lengths. A 256-character silent truncation was added as a band-aid to keep passwords short enough that these overflows never trigger.

## Changes

- `bruteforce_guesses` uses `.to_f` on the exponent so overflow produces `Infinity` (detectable) rather than silent Bignum; result capped at `Float::MAX`
- `estimate_attack_times` clamps each computed crack time to `Float::MAX`, since `Float::MAX / (100/hr)` still overflows to `Infinity`
- `FACTORIAL` and `MIN_GUESSES_POW` precomputed to their natural Float overflow boundaries (170 and 77); return `Float::MAX` for larger keys via a non-storing default proc; now frozen and private
- `bruteforce_guesses` returns Float consistently — was Integer for length-1 tokens
- 256-character silent truncation and `MAX_PASSWORD_LENGTH` constant removed
- Scoring time complexity and the caller responsibility for length limiting documented in YARD and README

## Consequences

- Passwords longer than 256 characters are now scored in full; all crack times remain finite
- Super-quadratic runtime for adversarial repeat inputs is no longer bounded by the library — callers must enforce a password length limit appropriate for their use case before calling `Zxcvbn.test` or `Zxcvbn::Tester#test`
- Behaviour aligns more closely with zxcvbn.js v4, which also has no length cap