### PR TITLE
Align year regex with zxcvbn.js v4 (1900–2019)

### DIFF
--- a/lib/zxcvbn/matchers/year.rb
+++ b/lib/zxcvbn/matchers/year.rb
@@ -4,12 +4,12 @@ require 'zxcvbn/matchers/regex_helpers'
 
 module Zxcvbn
   module Matchers
-    # Matches 4-digit year substrings (1900–2050) in the password.
+    # Matches 4-digit year substrings (1900–2019) in the password.
     class Year
       include RegexHelpers
 
-      # Matches years from 1900 to 2050.
-      YEAR_REGEX = /19\d\d|20[0-4]\d|2050/
+      # Matches years from 1900 to 2019, matching zxcvbn.js v4.
+      YEAR_REGEX = /19\d\d|200\d|201\d/
 
       # @param password [String]
       # @return [Array<Match>] matches with pattern "year"

--- a/spec/matchers/date_spec.rb
+++ b/spec/matchers/date_spec.rb
@@ -89,14 +89,15 @@ RSpec.describe Zxcvbn::Matchers::Date do
   end
 
   describe '#matches_year?' do
-    it 'recognises years up to 2050' do
-      expect(matcher.matches_year?('2025')).to be_truthy
-      expect(matcher.matches_year?('2050')).to be_truthy
+    it 'recognises years in the 1900–2019 range' do
       expect(matcher.matches_year?('1999')).to be_truthy
+      expect(matcher.matches_year?('2009')).to be_truthy
+      expect(matcher.matches_year?('2019')).to be_truthy
     end
 
-    it 'does not block legitimate date tokens' do
-      expect(matcher.matches_year?('2051')).to be_falsy
+    it 'does not block tokens outside the year range' do
+      expect(matcher.matches_year?('2020')).to be_falsy
+      expect(matcher.matches_year?('2025')).to be_falsy
       expect(matcher.matches_year?('1899')).to be_falsy
     end
   end


### PR DESCRIPTION
## Context

The year matcher regex covered 1900–2050, but zxcvbn.js v4 uses `/19\d\d|200\d|201\d/`, matching only 1900–2019. This caused a concrete score divergence: `'2025'` produced a `year` pattern match in Ruby with ~20 guesses, while JS treated it as a non-year token (scoring it via other matchers at much higher guesses).

## Changes

- `YEAR_REGEX` updated from `/19\d\d|20[0-4]\d|2050/` to `/19\d\d|200\d|201\d/`
- `Date#matches_year?` (which delegates to `YEAR_REGEX`) updated automatically
- Spec for `matches_year?` updated to reflect the narrowed range

## Consequences

Years from 2020 onward are no longer matched as standalone year tokens, and are instead eligible for date matching — the same behaviour as JS v4.