### PR TITLE
Memoize default Tester in Zxcvbn.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - YARD documentation for all public classes, modules, and methods ([#72])
 
 ### Changed
+ - `Zxcvbn.test` now reuses a shared `Tester` instance across calls, avoiding repeated dictionary parsing. Equivalent to using `Tester` directly for callers who do not pass custom `word_lists` ([#80])
  - `Zxcvbn::Score` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`calc_time=`, `feedback=`, etc.) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#74])
  - **Breaking**: `Zxcvbn::Feedback` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`warning=`, `suggestions=`) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#77])
  - **Breaking**: Scoring algorithm aligned with zxcvbn.js v4.4.2. The dynamic programming step now minimises total guesses (`factorial(l) × cumulative_product + MIN_GUESSES^(l-1)` penalty) instead of entropy bits. Scores for many passwords will change ([#69])
@@ -44,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#72]: https://github.com/envato/zxcvbn-ruby/pull/72
 [#74]: https://github.com/envato/zxcvbn-ruby/pull/74
 [#77]: https://github.com/envato/zxcvbn-ruby/pull/77
+[#80]: https://github.com/envato/zxcvbn-ruby/pull/80
 
 ## [1.4.0] - 2026-01-15
 

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -16,6 +16,11 @@ module Zxcvbn
 
   # Returns a Zxcvbn::Score for the given password.
   #
+  # Reuses a shared {Tester} instance (with pre-loaded dictionaries) when no
+  # custom +word_lists+ are given. For repeated calls without custom word lists,
+  # this is equivalent to using {Tester} directly. When +word_lists+ are
+  # provided, a fresh {Tester} is constructed each call.
+  #
   # Scoring time grows with password length: the DP is O(n × m) where n is
   # the password length and m is the number of pattern matches. For
   # adversarial inputs such as short repeated sequences (e.g. "ab" * 500),
@@ -26,8 +31,13 @@ module Zxcvbn
   #
   #   Zxcvbn.test("password").score #=> 0
   def test(password, user_inputs = [], word_lists = {})
-    tester = Tester.new
-    tester.add_word_lists(word_lists)
-    tester.test(password, user_inputs)
+    if word_lists.empty?
+      @default_tester ||= Tester.new
+      @default_tester.test(password, user_inputs)
+    else
+      tester = Tester.new
+      tester.add_word_lists(word_lists)
+      tester.test(password, user_inputs)
+    end
   end
 end


### PR DESCRIPTION
## Context

`Zxcvbn.test` constructs a fresh `Tester` on every call, loading ~94k dictionary entries and rebuilding 6 tries each time. The library's own test suite works around this by caching `ZXCVBN_TEST_DATA = Zxcvbn::Data.new` in `spec_helper.rb` — the public `Zxcvbn.test` API is inadvertently slower than what the test suite itself avoids.

## Changes

- `Zxcvbn.test` now reuses a shared `@default_tester` instance when no custom `word_lists` are provided
- When `word_lists` are given a fresh `Tester` is still constructed per call, since word lists persist on the tester and sharing would be incorrect
- YARD doc updated to describe the memoization behaviour

## Consequences

Repeated calls to `Zxcvbn.test` without custom word lists now have the same performance as using `Tester` directly. The `Tester` API remains the right choice for callers needing explicit lifecycle control or custom persistent word lists.