### PR TITLE
Fix thread-safety races in Scorer, Data, and Zxcvbn.test

### DIFF
--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -12,7 +12,12 @@ require 'zxcvbn/tester'
 module Zxcvbn
   module_function
 
+  # Path to the bundled data directory (frequency lists, adjacency graphs).
   DATA_PATH = Pathname(File.expand_path('../data', __dir__))
+
+  # Mutex protecting lazy initialisation of the shared default {Tester}.
+  DEFAULT_TESTER_MUTEX = Mutex.new
+  private_constant :DEFAULT_TESTER_MUTEX
 
   # Returns a Zxcvbn::Score for the given password.
   #
@@ -32,12 +37,17 @@ module Zxcvbn
   #   Zxcvbn.test("password").score #=> 0
   def test(password, user_inputs = [], word_lists = {})
     if word_lists.empty?
-      @default_tester ||= Tester.new
-      @default_tester.test(password, user_inputs)
+      default_tester.test(password, user_inputs)
     else
       tester = Tester.new
       tester.add_word_lists(word_lists)
       tester.test(password, user_inputs)
     end
   end
+
+  # @return [Tester] the shared default tester, constructed on first call
+  def default_tester
+    DEFAULT_TESTER_MUTEX.synchronize { @default_tester ||= Tester.new }
+  end
+  private_class_method :default_tester
 end

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -8,14 +8,23 @@ module Zxcvbn
   # Holds all loaded frequency lists, adjacency graphs, tries, and graph stats
   # used by the matchers and scorer.
   #
-  # @attr_reader ranked_dictionaries [Hash{String => Hash{String => Integer}}] word → rank maps
   # @attr_reader adjacency_graphs [Hash{String => Hash}] keyboard adjacency data
-  # @attr_reader dictionary_tries [Hash{String => Trie}] prefix tries per dictionary
   # @attr_reader graph_stats [Hash{String => Hash}] precomputed average degree and key count
+  # @attr_reader dictionaries [#ranked, #tries] consistent snapshot of ranked dictionaries and
+  #   their tries; use this for concurrent reads to guarantee the pair is always in sync
   class Data
+    # Consistent snapshot of ranked dictionaries and their tries.
+    # Stored as a single reference so it can be swapped atomically on update.
+    Dictionaries = ::Data.define(:ranked, :tries)
+    private_constant :Dictionaries
+
+    # Mutex serialising concurrent calls to {#add_word_list}.
+    WRITE_MUTEX = Mutex.new
+    private_constant :WRITE_MUTEX
+
     # Loads all built-in frequency lists and adjacency graphs from disk.
     def initialize
-      @ranked_dictionaries = DictionaryRanker.rank_dictionaries(
+      ranked = DictionaryRanker.rank_dictionaries(
         'english' => read_word_list('english.txt'),
         'female_names' => read_word_list('female_names.txt'),
         'male_names' => read_word_list('male_names.txt'),
@@ -23,22 +32,38 @@ module Zxcvbn
         'surnames' => read_word_list('surnames.txt'),
         'us_tv_and_film' => read_word_list('us_tv_and_film.txt')
       )
+      @dictionaries = Dictionaries.new(ranked:, tries: build_tries(ranked))
       @adjacency_graphs = JSON.parse(DATA_PATH.join('adjacency_graphs.json').read)
-      @dictionary_tries = build_tries
       @graph_stats = compute_graph_stats
     end
 
-    attr_reader :ranked_dictionaries, :adjacency_graphs, :dictionary_tries, :graph_stats
+    attr_reader :adjacency_graphs, :graph_stats, :dictionaries
+
+    # @return [Hash{String => Hash{String => Integer}}] word → rank maps
+    def ranked_dictionaries = @dictionaries.ranked
+
+    # @return [Hash{String => Trie}] prefix tries per dictionary
+    def dictionary_tries = @dictionaries.tries
 
     # Adds a custom word list and builds a trie for it.
+    #
+    # Safe to call concurrently with {#dictionaries} reads and with other
+    # {#add_word_list} calls. The mutex serialises writers; the atomic reference
+    # swap ensures readers always observe a consistent ranked/tries pair.
     #
     # @param name [String] dictionary name (used as a key in {#ranked_dictionaries})
     # @param list [Array<String>] ordered words (most common first)
     # @return [void]
     def add_word_list(name, list)
       ranked_dict = DictionaryRanker.rank_dictionary(list)
-      @ranked_dictionaries[name] = ranked_dict
-      @dictionary_tries[name] = build_trie(ranked_dict)
+      trie = build_trie(ranked_dict)
+      WRITE_MUTEX.synchronize do
+        old = @dictionaries
+        @dictionaries = Dictionaries.new(
+          ranked: old.ranked.merge(name => ranked_dict),
+          tries: old.tries.merge(name => trie)
+        )
+      end
     end
 
     private
@@ -47,8 +72,8 @@ module Zxcvbn
       DATA_PATH.join('frequency_lists', file).read.split
     end
 
-    def build_tries
-      @ranked_dictionaries.transform_values { |dict| build_trie(dict) }
+    def build_tries(ranked)
+      ranked.transform_values { |dict| build_trie(dict) }
     end
 
     def build_trie(ranked_dictionary)

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -60,8 +60,9 @@ module Zxcvbn
       n = password.length
       matches = []
 
-      matchers = @data.ranked_dictionaries.map do |name, dictionary|
-        trie = @data.dictionary_tries[name]
+      dicts = @data.dictionaries
+      matchers = dicts.ranked.map do |name, dictionary|
+        trie = dicts.tries[name]
         Matchers::Dictionary.new(name, dictionary, trie)
       end
 
@@ -86,8 +87,9 @@ module Zxcvbn
 
     def build_matchers
       matchers = []
-      dictionary_matchers = @data.ranked_dictionaries.map do |name, dictionary|
-        trie = @data.dictionary_tries[name]
+      dicts = @data.dictionaries
+      dictionary_matchers = dicts.ranked.map do |name, dictionary|
+        trie = dicts.tries[name]
         Matchers::Dictionary.new(name, dictionary, trie)
       end
       l33t_matcher = Matchers::L33t.new(dictionary_matchers)

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -2,6 +2,7 @@
 
 require 'zxcvbn/guesses'
 require 'zxcvbn/crack_time'
+require 'zxcvbn/omnimatch'
 require 'zxcvbn/score'
 require 'zxcvbn/match'
 
@@ -32,6 +33,7 @@ module Zxcvbn
     # @param data [Data] the loaded frequency list and graph data
     def initialize(data)
       @data = data
+      @omnimatch = Omnimatch.new(data)
     end
 
     attr_reader :data
@@ -136,8 +138,6 @@ module Zxcvbn
     # @return [Float] base_guesses * repeat_count
     def repeat_guesses(match, user_inputs: [])
       if match.base_guesses.nil?
-        require 'zxcvbn/omnimatch'
-        @omnimatch ||= Omnimatch.new(@data)
         base_matches  = @omnimatch.matches(match.base_token, user_inputs)
         base_analysis = most_guessable_match_sequence(match.base_token, base_matches, user_inputs:)
         match.base_guesses = base_analysis.guesses

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -131,8 +131,6 @@ module Zxcvbn
 
     # Compute guesses for a repeat match by recursively scoring the base token.
     #
-    # Lazily instantiates an {Omnimatch} when first needed.
-    #
     # @param match [Match] a repeat match with base_token set
     # @param user_inputs [Array] caller-supplied words passed through to sub-scoring
     # @return [Float] base_guesses * repeat_count

--- a/sig/zxcvbn/data.rbs
+++ b/sig/zxcvbn/data.rbs
@@ -4,15 +4,26 @@ module Zxcvbn
     type adjacency_graph = Hash[String, Array[String?]]
     type graph_stats = Hash[String, { average_degree: Float, starting_positions: Integer }]
 
-    @ranked_dictionaries: Hash[String, ranked_dictionary]
+    class Dictionaries
+      attr_reader ranked: Hash[String, ranked_dictionary]
+      attr_reader tries: Hash[String, Trie]
+
+      def initialize: (ranked: Hash[String, ranked_dictionary], tries: Hash[String, Trie]) -> void
+    end
+
+    WRITE_MUTEX: Mutex
+
+    @dictionaries: Dictionaries
     @adjacency_graphs: Hash[String, adjacency_graph]
-    @dictionary_tries: Hash[String, Trie]
     @graph_stats: graph_stats
 
-    attr_reader ranked_dictionaries: Hash[String, ranked_dictionary]
+    attr_reader dictionaries: Dictionaries
     attr_reader adjacency_graphs: Hash[String, adjacency_graph]
-    attr_reader dictionary_tries: Hash[String, Trie]
     attr_reader graph_stats: graph_stats
+
+    def ranked_dictionaries: () -> Hash[String, ranked_dictionary]
+
+    def dictionary_tries: () -> Hash[String, Trie]
 
     def initialize: () -> void
 
@@ -22,7 +33,7 @@ module Zxcvbn
 
     def read_word_list: (String file) -> Array[String]
 
-    def build_tries: () -> Hash[String, Trie]
+    def build_tries: (Hash[String, ranked_dictionary] ranked) -> Hash[String, Trie]
 
     def build_trie: (ranked_dictionary ranked_dictionary) -> Trie
 

--- a/sig/zxcvbn/scorer.rbs
+++ b/sig/zxcvbn/scorer.rbs
@@ -4,6 +4,7 @@ module Zxcvbn
     include CrackTime
 
     @data: Data
+    @omnimatch: Omnimatch
 
     attr_reader data: Data
 
@@ -11,6 +12,6 @@ module Zxcvbn
 
     def most_guessable_match_sequence: (String password, Array[Match] matches, ?exclude_additive: bool, ?user_inputs: Array[String]) -> Score
 
-    def repeat_guesses: (Match match) -> Numeric
+    def repeat_guesses: (Match match, ?user_inputs: Array[String]) -> Numeric
   end
 end

--- a/spec/scorer_spec.rb
+++ b/spec/scorer_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Zxcvbn::Scorer do
-  subject(:scorer) { described_class.new(nil) }
+  subject(:scorer) { described_class.new(ZXCVBN_TEST_DATA) }
 
   describe '#most_guessable_match_sequence' do
     context 'with an empty password' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'zxcvbn'
 
 Dir[Pathname.new(File.expand_path(__dir__)).join('support/**/*.rb')].each { |f| require f }
 
-ZXCVBN_TEST_DATA = Zxcvbn::Data.new
+ZXCVBN_TEST_DATA = Zxcvbn::Data.new.freeze
 
 RSpec.configure do |config|
   config.include JsHelpers


### PR DESCRIPTION
## Context

`Scorer#repeat_guesses` lazily initialised `@omnimatch` with `||=`, which is non-atomic: two threads scoring a repeat match simultaneously can both observe `nil` and construct separate instances.

`Data#add_word_list` updated `@ranked_dictionaries` and `@dictionary_tries` as two separate assignments. A concurrent reader could observe a mismatched pair — a dictionary entry with no corresponding trie. A concurrent writer could silently lose an update: both threads read the same snapshot, compute their own replacement, and the second write wins. `Omnimatch` compounded the reader race by reading the two attributes as separate method calls.

`Zxcvbn.test` had the same lazy-init race as `Scorer`: `@default_tester ||= Tester.new` is non-atomic under concurrent first calls.

## Changes

- `Omnimatch` is now initialised eagerly in `Scorer#initialize`, eliminating the `||=` race. The deferred `require` is moved to the top of the file.
- `ranked_dictionaries` and `dictionary_tries` are packaged into a single `Dictionaries` value object (`::Data.define`). `add_word_list` replaces the reference atomically so readers always observe a consistent ranked/tries pair. A `WRITE_MUTEX` serialises concurrent writers, preventing lost updates.
- `Omnimatch` snapshots `data.dictionaries` once per use so both fields always come from the same state.
- `Zxcvbn.test` wraps `@default_tester ||= Tester.new` in a `Mutex#synchronize`.
- `ZXCVBN_TEST_DATA` in `spec_helper.rb` is frozen to guard against accidental mutation across specs.
- `scorer_spec.rb` updated to pass `ZXCVBN_TEST_DATA` instead of `nil`, since `Scorer#initialize` now constructs an `Omnimatch` eagerly.
- YARD docs and RBS signatures updated to match the new API.

## Consequences

Concurrent calls to `Tester#test` and `Tester#add_word_lists` no longer risk mismatched dictionary/trie state, lost word-list updates, double-constructed omnimatch instances, or redundant `Tester` construction on first call to `Zxcvbn.test`.