### PR TITLE
Pass Omnimatch into Scorer instead of constructing a second instance

### DIFF
--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -11,7 +11,7 @@ module Zxcvbn
     # @param data [Data] loaded frequency lists and adjacency graphs
     def initialize(data)
       @omnimatch = Omnimatch.new(data)
-      @scorer = Scorer.new(data)
+      @scorer = Scorer.new(data, @omnimatch)
     end
 
     # Analyses password strength and returns a populated {Score}.

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -2,7 +2,6 @@
 
 require 'zxcvbn/guesses'
 require 'zxcvbn/crack_time'
-require 'zxcvbn/omnimatch'
 require 'zxcvbn/score'
 require 'zxcvbn/match'
 
@@ -31,9 +30,10 @@ module Zxcvbn
     private_constant :FACTORIAL, :MIN_GUESSES_POW
 
     # @param data [Data] the loaded frequency list and graph data
-    def initialize(data)
+    # @param omnimatch [Omnimatch] shared omnimatch instance
+    def initialize(data, omnimatch)
       @data = data
-      @omnimatch = Omnimatch.new(data)
+      @omnimatch = omnimatch
     end
 
     attr_reader :data

--- a/sig/zxcvbn/scorer.rbs
+++ b/sig/zxcvbn/scorer.rbs
@@ -8,7 +8,7 @@ module Zxcvbn
 
     attr_reader data: Data
 
-    def initialize: (Data data) -> void
+    def initialize: (Data data, Omnimatch omnimatch) -> void
 
     def most_guessable_match_sequence: (String password, Array[Match] matches, ?exclude_additive: bool, ?user_inputs: Array[String]) -> Score
 

--- a/spec/scorer_spec.rb
+++ b/spec/scorer_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Zxcvbn::Scorer do
-  subject(:scorer) { described_class.new(ZXCVBN_TEST_DATA) }
+  subject(:scorer) { described_class.new(ZXCVBN_TEST_DATA, Zxcvbn::Omnimatch.new(ZXCVBN_TEST_DATA)) }
 
   describe '#most_guessable_match_sequence' do
     context 'with an empty password' do


### PR DESCRIPTION
## Context

`PasswordStrength` owns an `Omnimatch` built from `Data`. `Scorer` also constructs its own `Omnimatch` over the same `Data`, producing a redundant allocation on every `PasswordStrength#test` call.

## Changes

`Omnimatch` ownership is moved to `PasswordStrength`, which passes the shared instance into `Scorer`:

- `Scorer#initialize` now accepts an `Omnimatch` parameter alongside `Data`
- `PasswordStrength` passes its own `@omnimatch` into `Scorer.new`
- `require 'zxcvbn/omnimatch'` removed from `scorer.rb` (ownership moves to `PasswordStrength`)
- RBS signature for `Scorer#initialize` updated to match
- Scorer spec updated to construct `Omnimatch` explicitly

## Consequences

One fewer `Omnimatch` allocation per password test. `Scorer`'s public API gains a required `omnimatch` argument — callers constructing `Scorer` directly (e.g. in tests) must now pass one.