### PR TITLE
Score repeat base tokens without user inputs, matching JS v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - `Zxcvbn.test` now reuses a shared `Tester` instance across calls, avoiding repeated dictionary parsing. Equivalent to using `Tester` directly for callers who do not pass custom `word_lists` ([#80])
+ - Repeat base tokens are now scored without `user_inputs`, matching zxcvbn.js v4. Previously, user-supplied words were propagated into the recursive scoring of a repeat's base token, causing repeat matches of user-supplied words to score lower than JS would report ([#83])
  - `Zxcvbn::Score` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`calc_time=`, `feedback=`, etc.) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#74])
  - **Breaking**: `Zxcvbn::Feedback` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`warning=`, `suggestions=`) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#77])
  - **Breaking**: Scoring algorithm aligned with zxcvbn.js v4.4.2. The dynamic programming step now minimises total guesses (`factorial(l) × cumulative_product + MIN_GUESSES^(l-1)` penalty) instead of entropy bits. Scores for many passwords will change ([#69])
@@ -46,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#74]: https://github.com/envato/zxcvbn-ruby/pull/74
 [#77]: https://github.com/envato/zxcvbn-ruby/pull/77
 [#80]: https://github.com/envato/zxcvbn-ruby/pull/80
+[#83]: https://github.com/envato/zxcvbn-ruby/pull/83
 
 ## [1.4.0] - 2026-01-15
 

--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -31,9 +31,8 @@ module Zxcvbn
     #
     # @param match [Match] the match to estimate
     # @param password [String] the full password being evaluated
-    # @param user_inputs [Array] caller-supplied words forwarded to repeat sub-scoring
     # @return [Integer] estimated number of guesses
-    def estimate_guesses(match, password, user_inputs: [])
+    def estimate_guesses(match, password)
       return match.guesses if match.guesses
 
       min_guesses =
@@ -48,7 +47,7 @@ module Zxcvbn
         in 'bruteforce' then bruteforce_guesses(match)
         in 'dictionary' then dictionary_guesses(match)
         in 'spatial'    then spatial_guesses(match)
-        in 'repeat'     then repeat_guesses(match, user_inputs:)
+        in 'repeat'     then repeat_guesses(match)
         in 'sequence'   then sequence_guesses(match)
         in 'digits'     then digits_guesses(match)
         in 'year'       then year_guesses(match)
@@ -71,10 +70,8 @@ module Zxcvbn
     end
 
     # @param match [Match] a repeat match with base_guesses and repeat_count set
-    # @param user_inputs [Array] unused in this base implementation; present so
-    #   overrides (e.g. {Scorer}) can receive the value without changing the callsite
     # @return [Integer] base_guesses multiplied by the number of repetitions
-    def repeat_guesses(match, user_inputs: []) # rubocop:disable Lint/UnusedMethodArgument
+    def repeat_guesses(match)
       match.base_guesses * match.repeat_count
     end
 

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -24,7 +24,7 @@ module Zxcvbn
       result = nil
       calc_time = Clock.realtime do
         matches = @omnimatch.matches(password, user_inputs)
-        result = @scorer.most_guessable_match_sequence(password, matches, user_inputs:)
+        result = @scorer.most_guessable_match_sequence(password, matches)
       end
       result.with(
         calc_time:,

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -52,7 +52,7 @@ module Zxcvbn
     # @param exclude_additive [Boolean] omit the sequence-length penalty
     #   (used when recursively analysing repeat base tokens)
     # @return [Score] the optimal score with match sequence and guess count
-    def most_guessable_match_sequence(password, matches, exclude_additive: false, user_inputs: [])
+    def most_guessable_match_sequence(password, matches, exclude_additive: false)
       n = password.length
 
       return build_score(password, [], 1) if n.zero?
@@ -74,7 +74,7 @@ module Zxcvbn
 
       update = lambda do |match, l|
         j       = match.j
-        est     = estimate_guesses(match, password, user_inputs:)
+        est     = estimate_guesses(match, password)
         pi_prev = l > 1 ? pi_float[match.i - 1][l - 1] : 1.0
         candidate = FACTORIAL[l] * est * pi_prev
         candidate += MIN_GUESSES_POW[l - 1] unless exclude_additive
@@ -132,12 +132,11 @@ module Zxcvbn
     # Compute guesses for a repeat match by recursively scoring the base token.
     #
     # @param match [Match] a repeat match with base_token set
-    # @param user_inputs [Array] caller-supplied words passed through to sub-scoring
     # @return [Float] base_guesses * repeat_count
-    def repeat_guesses(match, user_inputs: [])
+    def repeat_guesses(match)
       if match.base_guesses.nil?
-        base_matches  = @omnimatch.matches(match.base_token, user_inputs)
-        base_analysis = most_guessable_match_sequence(match.base_token, base_matches, user_inputs:)
+        base_matches  = @omnimatch.matches(match.base_token)
+        base_analysis = most_guessable_match_sequence(match.base_token, base_matches)
         match.base_guesses = base_analysis.guesses
       end
       match.base_guesses * match.repeat_count

--- a/sig/zxcvbn/guesses.rbs
+++ b/sig/zxcvbn/guesses.rbs
@@ -11,11 +11,11 @@ module Zxcvbn
     ALL_UPPER: Regexp
     ALL_LOWER: Regexp
 
-    def estimate_guesses: (Match match, String password, ?user_inputs: Array[untyped]) -> Numeric
+    def estimate_guesses: (Match match, String password) -> Numeric
 
     def bruteforce_guesses: (Match match) -> Numeric
 
-    def repeat_guesses: (Match match, ?user_inputs: Array[untyped]) -> Numeric
+    def repeat_guesses: (Match match) -> Numeric
 
     def sequence_guesses: (Match match) -> Numeric
 

--- a/sig/zxcvbn/scorer.rbs
+++ b/sig/zxcvbn/scorer.rbs
@@ -10,8 +10,8 @@ module Zxcvbn
 
     def initialize: (Data data, Omnimatch omnimatch) -> void
 
-    def most_guessable_match_sequence: (String password, Array[Match] matches, ?exclude_additive: bool, ?user_inputs: Array[String]) -> Score
+    def most_guessable_match_sequence: (String password, Array[Match] matches, ?exclude_additive: bool) -> Score
 
-    def repeat_guesses: (Match match, ?user_inputs: Array[String]) -> Numeric
+    def repeat_guesses: (Match match) -> Numeric
   end
 end


### PR DESCRIPTION
## Context

`Scorer#repeat_guesses` scores a repeat match by recursively analysing its base token (e.g. the `"abc"` in `"abcabc"`). Ruby propagates `user_inputs` through that recursive path — into both `Omnimatch#matches` and `most_guessable_match_sequence` — so a repeat of a user-supplied word is scored lower than JS v4 would score it. JS scores the base token in isolation, without user inputs. This divergence is relevant because the library is used alongside the JS frontend; divergent scores for the same password undermine that pairing.

## Changes

- `Scorer#repeat_guesses` scores the base token without user inputs, matching JS v4
- `user_inputs:` removed from `repeat_guesses`, `estimate_guesses`, and `most_guessable_match_sequence` — it was only ever forwarded to the repeat path
- RBS signatures and YARD docs updated accordingly
- Changelog entry added

## Consequences

- Repeat matches of user-supplied words now produce the same score as JS v4
- `most_guessable_match_sequence` and `repeat_guesses` have simpler signatures