### PR TITLE
Fix YARD return types and replace tautological DP scorer tests

### DIFF
--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -31,7 +31,7 @@ module Zxcvbn
     #
     # @param match [Match] the match to estimate
     # @param password [String] the full password being evaluated
-    # @return [Integer] estimated number of guesses
+    # @return [Numeric] estimated number of guesses
     def estimate_guesses(match, password)
       return match.guesses if match.guesses
 
@@ -61,7 +61,7 @@ module Zxcvbn
     end
 
     # @param match [Match] a bruteforce match
-    # @return [Float] guesses based on token length and assumed cardinality
+    # @return [Numeric] guesses based on token length and assumed cardinality
     def bruteforce_guesses(match)
       guesses = BRUTEFORCE_CARDINALITY**match.token.length.to_f
       guesses = Float::MAX if guesses.infinite?
@@ -70,7 +70,7 @@ module Zxcvbn
     end
 
     # @param match [Match] a repeat match with base_guesses and repeat_count set
-    # @return [Integer] base_guesses multiplied by the number of repetitions
+    # @return [Numeric] base_guesses multiplied by the number of repetitions
     def repeat_guesses(match)
       match.base_guesses * match.repeat_count
     end
@@ -115,7 +115,7 @@ module Zxcvbn
     end
 
     # @param match [Match] a spatial (keyboard pattern) match
-    # @return [Integer] guesses based on graph topology, turns, and shifted keys
+    # @return [Numeric] guesses based on graph topology, turns, and shifted keys
     def spatial_guesses(match)
       if %w[qwerty dvorak].include?(match.graph)
         s = starting_positions_for_graph('qwerty')

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -132,7 +132,7 @@ module Zxcvbn
     # Compute guesses for a repeat match by recursively scoring the base token.
     #
     # @param match [Match] a repeat match with base_token set
-    # @return [Float] base_guesses * repeat_count
+    # @return [Numeric] base_guesses * repeat_count
     def repeat_guesses(match)
       if match.base_guesses.nil?
         base_matches  = @omnimatch.matches(match.base_token)

--- a/spec/scorer_spec.rb
+++ b/spec/scorer_spec.rb
@@ -24,12 +24,20 @@ RSpec.describe Zxcvbn::Scorer do
       end
     end
 
-    context 'with a single match spanning the full password' do
-      it 'selects the match over a bruteforce fallback' do
+    context 'when a match covers the full password' do
+      it 'prefers a cheap match over bruteforce' do
         match = Zxcvbn::Match.new(pattern: 'dictionary', i: 0, j: 2, token: 'abc', rank: 1)
         result = scorer.most_guessable_match_sequence('abc', [match])
-        expect(result.guesses).to eq 2
         expect(result.sequence).to eq [match]
+        expect(result.guesses).to be < 1001 # cheaper than bruteforce of 'abc' (10^3 + 1)
+      end
+
+      it 'prefers bruteforce when the match exceeds its cost' do
+        # rank=2000 → match guesses=2001; bruteforce of 'abc' = 1001
+        match = Zxcvbn::Match.new(pattern: 'dictionary', i: 0, j: 2, token: 'abc', rank: 2000)
+        result = scorer.most_guessable_match_sequence('abc', [match])
+        expect(result.sequence.length).to eq 1
+        expect(result.sequence.first.pattern).to eq 'bruteforce'
       end
     end
 
@@ -65,11 +73,15 @@ RSpec.describe Zxcvbn::Scorer do
       end
     end
 
-    context 'bruteforce chain prevention' do
-      it 'does not build a multi-match sequence from bruteforce segments only' do
-        result = scorer.most_guessable_match_sequence('ab', [])
-        expect(result.sequence.count).to eq 1
-        expect(result.sequence.first.token).to eq 'ab'
+    context 'with a partial match leaving a gap' do
+      it 'fills the uncovered region with bruteforce' do
+        # match covers 'abcd'; DP must cover 'efgh' with bruteforce
+        match = Zxcvbn::Match.new(pattern: 'dictionary', i: 0, j: 3, token: 'abcd', rank: 1)
+        result = scorer.most_guessable_match_sequence('abcdefgh', [match])
+        expect(result.sequence.length).to eq 2
+        expect(result.sequence.first).to eq match
+        expect(result.sequence.last.pattern).to eq 'bruteforce'
+        expect(result.sequence.last.token).to eq 'efgh'
       end
     end
   end


### PR DESCRIPTION
## Context

Two unrelated issues in the same area:

`estimate_guesses`, `repeat_guesses`, `bruteforce_guesses`, and `spatial_guesses` in `Guesses` are annotated `@return [Integer]` or `@return [Float]`, but all guess-returning methods should use `Numeric` for consistency with the RBS signatures and to reflect that the return type varies by pattern (bruteforce returns Float, dictionary returns Integer, etc.).

Two scorer tests were tautological. The match-vs-bruteforce test used `rank: 1` (guesses=2 vs bruteforce=1001), so the DP could not fail regardless of how it compares options. The bruteforce chain prevention test passed without the prevention code, because the cost structure already makes bruteforce chaining more expensive than a single bruteforce segment — the test was not actually exercising the code path it claimed to.

## Changes

- All guess-returning YARD `@return` annotations unified to `[Numeric]`, consistent with existing RBS signatures
- "selects the match over a bruteforce fallback" replaced with two tests: one where a cheap match wins, one where an expensive match loses to bruteforce — the second test actually exercises the DP's comparison
- "does not build a multi-match sequence from bruteforce segments only" replaced with a test that shows the DP filling an uncovered region with bruteforce after a partial match

## Consequences

- YARD docs and RBS signatures are consistent
- Scorer tests now fail if the DP stops comparing matches against bruteforce cost