### PR TITLE
Add missing reversed-word suggestion to dictionary match feedback

### DIFF
--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -151,6 +151,8 @@ module Zxcvbn
         )
       end
 
+      suggestions.push("Reversed words aren't much harder to guess") if match.reversed && match.token.length >= 4
+
       if match.l33t
         suggestions.push(
           "Predictable substitutions like '@' instead of 'a' \

--- a/spec/feedback_giver_spec.rb
+++ b/spec/feedback_giver_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe Zxcvbn::FeedbackGiver do
           )
         end
 
+        it 'that are a reversed common password' do
+          feedback = tester.test('drowssap').feedback
+
+          expect(feedback).to be_a Zxcvbn::Feedback
+          expect(feedback.warning).to eql(
+            'This is similar to a commonly used password'
+          )
+          expect(feedback.suggestions).to include(
+            "Reversed words aren't much harder to guess"
+          )
+        end
+
         it 'that are common and you tried to use l33tsp33k' do
           feedback = tester.test('p@ssword').feedback
 


### PR DESCRIPTION
## Context

\`FeedbackGiver\` produces suggestions for dictionary matches based on characteristics of the match — capitalisation, l33t substitution, etc. zxcvbn.js v4 also pushes \`"Reversed words aren't much harder to guess"\` when a dictionary match is reversed and the token is at least 4 characters long. Ruby is missing this branch, so passwords like \`"drowssap"\` (reversed \`"password"\`) receive no hint that reversing a common word provides little protection.

## Changes

- Added the reversed-word suggestion to \`FeedbackGiver.get_dictionary_match_feedback\`, matching JS v4 exactly: fires when \`match.reversed && match.token.length >= 4\`
- Added a test covering a reversed common password (\`"drowssap"\`)

## Consequences

- Reversed common passwords now surface the suggestion, consistent with JS v4