### PR TITLE
Remove hyphen from SHIFTED_RX, matching zxcvbn.js v4

### DIFF
--- a/lib/zxcvbn/matchers/spatial.rb
+++ b/lib/zxcvbn/matchers/spatial.rb
@@ -8,7 +8,7 @@ module Zxcvbn
     # configured adjacency graphs.
     class Spatial
       # Matches characters that require the Shift key on a standard keyboard.
-      SHIFTED_RX = /[~!@#$%^&*()\-_+QWERTYUIOP{}|ASDFGHJKL:"ZXCVBNM<>?]/
+      SHIFTED_RX = /[~!@#$%^&*()_+QWERTYUIOP{}|ASDFGHJKL:"ZXCVBNM<>?]/
 
       # @param graphs [Hash{String => Hash}] adjacency graph data keyed by graph name
       def initialize(graphs)


### PR DESCRIPTION
## Context

`SHIFTED_RX` in `Matchers::Spatial` identifies characters that require the Shift key, used to count `shifted_count` on spatial matches. Ruby's regex includes `\-` (hyphen), but hyphen is an unshifted key on a standard US keyboard — its shifted counterpart is `_` (underscore), which is already in the set. The zxcvbn.js v4 regex omits the hyphen entirely. Passwords containing hyphens in spatial patterns currently overcount `shifted_count`, producing a higher guess estimate than JS.

## Changes

- Removed `\-` from `SHIFTED_RX`, aligning it exactly with the JS v4 regex

## Consequences

- Spatial matches containing hyphens now report the correct `shifted_count`, consistent with JS v4