### PR TITLE
Remove Guesses#repeat_guesses stub — Scorer always overrides it

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -41,7 +41,6 @@ Metrics/CyclomaticComplexity:
     - 'lib/zxcvbn/matchers/date.rb'
     - 'lib/zxcvbn/matchers/sequences.rb'
     - 'lib/zxcvbn/matchers/spatial.rb'
-    - 'lib/zxcvbn/math.rb'
     - 'lib/zxcvbn/scorer.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -54,11 +53,9 @@ Metrics/MethodLength:
     - 'lib/zxcvbn/matchers/date.rb'
     - 'lib/zxcvbn/matchers/dictionary.rb'
     - 'lib/zxcvbn/matchers/l33t.rb'
-    - 'lib/zxcvbn/matchers/regex_helpers.rb'
     - 'lib/zxcvbn/matchers/repeat.rb'
     - 'lib/zxcvbn/matchers/sequences.rb'
     - 'lib/zxcvbn/matchers/spatial.rb'
-    - 'lib/zxcvbn/math.rb'
     - 'lib/zxcvbn/omnimatch.rb'
     - 'lib/zxcvbn/scorer.rb'
 
@@ -89,7 +86,6 @@ Naming/MethodName:
 Naming/MethodParameterName:
   Exclude:
     - 'lib/zxcvbn/math.rb'
-    - 'lib/zxcvbn/scorer.rb'
 
 # Configuration parameters: AllowedVariables.
 Style/GlobalVars:

--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -69,12 +69,6 @@ module Zxcvbn
       [guesses, min].max
     end
 
-    # @param match [Match] a repeat match with base_guesses and repeat_count set
-    # @return [Numeric] base_guesses multiplied by the number of repetitions
-    def repeat_guesses(match)
-      match.base_guesses * match.repeat_count
-    end
-
     # @param match [Match] a sequence match (e.g. "abc", "6543")
     # @return [Integer] guesses based on sequence type and direction
     def sequence_guesses(match)

--- a/sig/zxcvbn/guesses.rbs
+++ b/sig/zxcvbn/guesses.rbs
@@ -15,8 +15,6 @@ module Zxcvbn
 
     def bruteforce_guesses: (Match match) -> Numeric
 
-    def repeat_guesses: (Match match) -> Numeric
-
     def sequence_guesses: (Match match) -> Numeric
 
     def digits_guesses: (Match match) -> Integer

--- a/spec/guesses_spec.rb
+++ b/spec/guesses_spec.rb
@@ -35,13 +35,6 @@ RSpec.describe Zxcvbn::Guesses do
     end
   end
 
-  describe '#repeat_guesses' do
-    it 'multiplies base_guesses by repeat_count' do
-      m = make_match(base_guesses: 10, repeat_count: 3)
-      expect(host.repeat_guesses(m)).to eq 30
-    end
-  end
-
   describe '#sequence_guesses' do
     it 'uses base 4 for common sequence starters' do
       %w[a A z Z 0 1 9].each do |char|
@@ -215,11 +208,6 @@ RSpec.describe Zxcvbn::Guesses do
     it 'dispatches to sequence_guesses for sequence pattern' do
       m = make_match(pattern: 'sequence', token: 'bcd', ascending: true)
       expect(host.estimate_guesses(m, 'bcd')).to eq 78
-    end
-
-    it 'dispatches to repeat_guesses for repeat pattern' do
-      m = make_match(pattern: 'repeat', token: 'aaaa', base_guesses: 5, repeat_count: 4)
-      expect(host.estimate_guesses(m, 'aaaa')).to eq 20
     end
 
     it 'dispatches to digits_guesses for digits pattern' do


### PR DESCRIPTION
## Context

`Guesses#repeat_guesses` assumes `base_guesses` is pre-populated on the match (`match.base_guesses * match.repeat_count`), but the `Repeat` matcher never sets it — `base_guesses` is always `nil` on a fresh match. In production, `Scorer` overrides `repeat_guesses` with a recursive scoring implementation that lazily computes `base_guesses`. The base method in `Guesses` is unreachable in practice and broken if called directly (`nil * repeat_count` raises).

## Changes

- `Guesses#repeat_guesses` removed
- RBS signature for the method removed
- Unit test for the base implementation removed
- `estimate_guesses` dispatch test for the repeat pattern removed (it exercised the base implementation through the `Guesses` test host, which no longer has the method)

## Consequences

- `Scorer#repeat_guesses` remains the sole implementation, which is the only correct one
- The removal is honest: `Guesses` cannot handle repeat matches standalone