### PR TITLE
Align display_time with zxcvbn.js v4

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,6 +36,7 @@ Metrics/ClassLength:
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/CyclomaticComplexity:
   Exclude:
+    - 'lib/zxcvbn/crack_time.rb'
     - 'lib/zxcvbn/feedback_giver.rb'
     - 'lib/zxcvbn/guesses.rb'
     - 'lib/zxcvbn/matchers/date.rb'
@@ -67,6 +68,7 @@ Metrics/ModuleLength:
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/PerceivedComplexity:
   Exclude:
+    - 'lib/zxcvbn/crack_time.rb'
     - 'lib/zxcvbn/feedback_giver.rb'
     - 'lib/zxcvbn/guesses.rb'
     - 'lib/zxcvbn/matchers/date.rb'

--- a/lib/zxcvbn/crack_time.rb
+++ b/lib/zxcvbn/crack_time.rb
@@ -58,18 +58,26 @@ module Zxcvbn
       year    = month * 12
       century = year * 100
 
-      if seconds < minute
-        'instant'
+      if seconds < 1
+        'less than a second'
+      elsif seconds < minute
+        t = seconds.round
+        "#{t} second#{'s' unless t == 1}"
       elsif seconds < hour
-        "#{1 + (seconds / minute).ceil} minutes"
+        t = (seconds / minute).round
+        "#{t} minute#{'s' unless t == 1}"
       elsif seconds < day
-        "#{1 + (seconds / hour).ceil} hours"
+        t = (seconds / hour).round
+        "#{t} hour#{'s' unless t == 1}"
       elsif seconds < month
-        "#{1 + (seconds / day).ceil} days"
+        t = (seconds / day).round
+        "#{t} day#{'s' unless t == 1}"
       elsif seconds < year
-        "#{1 + (seconds / month).ceil} months"
+        t = (seconds / month).round
+        "#{t} month#{'s' unless t == 1}"
       elsif seconds < century
-        "#{1 + (seconds / year).ceil} years"
+        t = (seconds / year).round
+        "#{t} year#{'s' unless t == 1}"
       else
         'centuries'
       end

--- a/spec/scoring/crack_time_spec.rb
+++ b/spec/scoring/crack_time_spec.rb
@@ -88,28 +88,45 @@ RSpec.describe Zxcvbn::CrackTime do
     let(:year)    { month * 12 }
     let(:century) { year * 100 }
 
-    it 'returns instant for less than a minute' do
-      [0, minute - 1].each { |s| expect(display_time(s)).to eq 'instant' }
+    it 'returns "less than a second" for under 1 second' do
+      expect(display_time(0)).to eq 'less than a second'
+      expect(display_time(0.9)).to eq 'less than a second'
+    end
+
+    it 'returns seconds for less than a minute' do
+      expect(display_time(1)).to eq '1 second'
+      expect(display_time(30)).to eq '30 seconds'
+      expect(display_time(minute - 1)).to match(/\d+ seconds$/)
     end
 
     it 'returns minutes for less than an hour' do
-      [minute, hour - 1].each { |s| expect(display_time(s)).to match(/\d+ minutes$/) }
+      expect(display_time(minute)).to eq '1 minute'
+      expect(display_time(minute * 2)).to eq '2 minutes'
+      expect(display_time(hour - 1)).to match(/\d+ minutes$/)
     end
 
     it 'returns hours for less than a day' do
-      [hour, day - 1].each { |s| expect(display_time(s)).to match(/\d+ hours$/) }
+      expect(display_time(hour)).to eq '1 hour'
+      expect(display_time(hour * 2)).to eq '2 hours'
+      expect(display_time(day - 1)).to match(/\d+ hours$/)
     end
 
     it 'returns days for less than a month' do
-      [day, month - 1].each { |s| expect(display_time(s)).to match(/\d+ days$/) }
+      expect(display_time(day)).to eq '1 day'
+      expect(display_time(day * 2)).to eq '2 days'
+      expect(display_time(month - 1)).to match(/\d+ days$/)
     end
 
     it 'returns months for less than a year' do
-      [month, year - 1].each { |s| expect(display_time(s)).to match(/\d+ months$/) }
+      expect(display_time(month)).to eq '1 month'
+      expect(display_time(month * 2)).to eq '2 months'
+      expect(display_time(year - 1)).to match(/\d+ months$/)
     end
 
     it 'returns years for less than a century' do
-      [year, century - 1].each { |s| expect(display_time(s)).to match(/\d+ years$/) }
+      expect(display_time(year)).to eq '1 year'
+      expect(display_time(year * 2)).to eq '2 years'
+      expect(display_time(century - 1)).to match(/\d+ years$/)
     end
 
     it 'returns centuries for a century or more' do


### PR DESCRIPTION
## Context

`display_time` produces the human-readable strings in `crack_times_display`. It diverges from zxcvbn.js v4 in three ways:

- Inputs under 60 seconds return `"instant"`; JS returns `"less than a second"` for `< 1s` and `"N second(s)"` for 1–59s
- Rounding uses `1 + ceil(x / unit)`; JS uses `Math.round(x / unit)`, so a 90-second crack time displays as `"3 minutes"` in Ruby but `"2 minutes"` in JS
- Units are always plural (`"minutes"`, `"hours"`); JS singularises when the count is 1 (`"1 minute"`, `"2 minutes"`)

Since the library is used alongside the JS frontend, divergent `crack_times_display` strings for the same password undermine that pairing.

## Changes

- `display_time` rewritten to match JS v4 exactly: `"less than a second"` for sub-second, `"N second(s)"` for 1–59s, `Math.round`-based rounding, and correct singularisation
- Spec updated to cover singular/plural forms and the sub-second bucket
- `crack_time.rb` added to rubocop complexity exclusions (linear dispatch table)

## Consequences

- `crack_times_display` strings now match JS v4 output for the same guess count