### PR TITLE
Memoize reference year per scoring run

### DIFF
--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -94,14 +94,12 @@ module Zxcvbn
     # @param match [Match] a year match
     # @return [Integer] distance from the current year, floored at {MIN_YEAR_SPACE}
     def year_guesses(match)
-      reference_year = Time.now.year
       [(match.token.to_i - reference_year).abs, MIN_YEAR_SPACE].max
     end
 
     # @param match [Match] a date match with year and separator set
     # @return [Integer] 365 * year_space, multiplied by 4 if a separator is present
     def date_guesses(match)
-      reference_year = Time.now.year
       year_space = [(match.year - reference_year).abs, MIN_YEAR_SPACE].max
       guesses = 365 * year_space
       guesses *= 4 if match.separator && !match.separator.empty?
@@ -201,6 +199,10 @@ module Zxcvbn
         end
       end
       variations
+    end
+
+    def reference_year
+      @reference_year ||= Time.now.year
     end
   end
 end


### PR DESCRIPTION
## Context

`year_guesses` and `date_guesses` both use the current year as a reference point when computing how many guesses a year or date match is worth. A password containing a year close to the present day scores lower (fewer guesses) than one containing a distant year.

## Changes

- Extract `reference_year` as a memoized method on `Guesses` (`@reference_year ||= Time.now.year`)
- Both `year_guesses` and `date_guesses` call `reference_year` instead of `Time.now.year` directly

## Consequences

A single scoring run always uses one consistent reference year. Previously, two matches in the same run could call `Time.now.year` independently and see different values if the call straddled midnight on New Year's Eve, producing internally inconsistent guesses estimates. The memoization is per-instance, so the spec's minimal host and each production `Scorer` (constructed fresh per `Tester#test` call) get independent captures.