### PR TITLE
Mark internal classes @api private; hide DATA_PATH constant

### DIFF
--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -14,6 +14,7 @@ module Zxcvbn
 
   # Path to the bundled data directory (frequency lists, adjacency graphs).
   DATA_PATH = Pathname(File.expand_path('../data', __dir__))
+  private_constant :DATA_PATH
 
   # Mutex protecting lazy initialisation of the shared default {Tester}.
   DEFAULT_TESTER_MUTEX = Mutex.new

--- a/lib/zxcvbn/clock.rb
+++ b/lib/zxcvbn/clock.rb
@@ -2,6 +2,7 @@
 
 module Zxcvbn
   # Monotonic-clock utility for measuring elapsed wall time.
+  # @api private
   module Clock
     # Yields to the block and returns the elapsed time in seconds.
     #

--- a/lib/zxcvbn/crack_time.rb
+++ b/lib/zxcvbn/crack_time.rb
@@ -5,6 +5,7 @@ module Zxcvbn
   #
   # Provides {estimate_attack_times}, {guesses_to_score}, and {display_time}
   # mirroring the crack-time logic from zxcvbn.js v4.
+  # @api private
   module CrackTime
     ATTACK_SCENARIOS = {
       'online_throttling_100_per_hour' => 100.0 / 3600,

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -12,6 +12,7 @@ module Zxcvbn
   # @attr_reader graph_stats [Hash{String => Hash}] precomputed average degree and key count
   # @attr_reader dictionaries [#ranked, #tries] consistent snapshot of ranked dictionaries and
   #   their tries; use this for concurrent reads to guarantee the pair is always in sync
+  # @api private
   class Data
     # Consistent snapshot of ranked dictionaries and their tries.
     # Stored as a single reference so it can be swapped atomically on update.

--- a/lib/zxcvbn/dictionary_ranker.rb
+++ b/lib/zxcvbn/dictionary_ranker.rb
@@ -2,6 +2,7 @@
 
 module Zxcvbn
   # Converts raw word lists into frequency-ranked dictionaries for matcher use.
+  # @api private
   class DictionaryRanker
     # Ranks multiple word lists, returning a hash of ranked dictionaries.
     #

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -5,6 +5,7 @@ require 'zxcvbn/feedback'
 
 module Zxcvbn
   # Generates human-readable {Feedback} for a password given its score and match sequence.
+  # @api private
   class FeedbackGiver
     NAME_DICTIONARIES = %w[surnames male_names female_names].freeze
 

--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -8,6 +8,7 @@ module Zxcvbn
   # Each pattern-specific method returns a raw guess count; {estimate_guesses}
   # applies a per-token minimum and memoises the result on the match object.
   # Mirrors the guesses estimation logic from zxcvbn.js v4.
+  # @api private
   module Guesses
     include Zxcvbn::Math
 

--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -4,6 +4,7 @@ module Zxcvbn
   module Matchers
     # Matches date patterns in passwords, both with and without separators.
     # Ported from the zxcvbn v4 JavaScript implementation's +date_match+ function.
+    # @api private
     class Date
       # Matches a separator-based date substring (e.g. "02/12/1997", "97-12-02").
       # The first and last groups each allow 1–4 digits so the year may appear in

--- a/lib/zxcvbn/matchers/dictionary.rb
+++ b/lib/zxcvbn/matchers/dictionary.rb
@@ -6,6 +6,7 @@ module Zxcvbn
   module Matchers
     # Matches any sequential segment of the lowercased password that appears in
     # a ranked dictionary.
+    # @api private
     class Dictionary
       # @param name [String] dictionary identifier used in match results
       # @param ranked_dictionary [Hash{String => Integer}] lowercased word → rank

--- a/lib/zxcvbn/matchers/digits.rb
+++ b/lib/zxcvbn/matchers/digits.rb
@@ -5,6 +5,7 @@ require 'zxcvbn/matchers/regex_helpers'
 module Zxcvbn
   module Matchers
     # Matches runs of 3 or more consecutive digits in the password.
+    # @api private
     class Digits
       include RegexHelpers
 

--- a/lib/zxcvbn/matchers/l33t.rb
+++ b/lib/zxcvbn/matchers/l33t.rb
@@ -4,6 +4,7 @@ module Zxcvbn
   module Matchers
     # Matches dictionary words after substituting common l33t-speak character
     # replacements (e.g. "@" for "a", "3" for "e").
+    # @api private
     class L33t
       # Mapping from plain letter to the l33t characters that can represent it.
       L33T_TABLE = {

--- a/lib/zxcvbn/matchers/regex_helpers.rb
+++ b/lib/zxcvbn/matchers/regex_helpers.rb
@@ -4,8 +4,10 @@ require 'zxcvbn/match_builder'
 
 module Zxcvbn
   # Namespace for all password pattern matchers.
+  # @api private
   module Matchers
     # Shared helper for iterating non-overlapping regex matches over a password.
+    # @api private
     module RegexHelpers
       # Yields a {Match} and the underlying MatchData for every non-overlapping
       # occurrence of regex in password.

--- a/lib/zxcvbn/matchers/repeat.rb
+++ b/lib/zxcvbn/matchers/repeat.rb
@@ -9,6 +9,7 @@ module Zxcvbn
     # Uses a greedy/lazy regex disambiguation strategy from zxcvbn.js v4:
     # prefer the greedier match unless the lazy match is longer, then use
     # LAZY_ANCHORED to extract the minimal repeating unit (base_token).
+    # @api private
     class Repeat
       # Greedily matches the longest repeated substring.
       GREEDY        = /(.+)\1+/

--- a/lib/zxcvbn/matchers/sequences.rb
+++ b/lib/zxcvbn/matchers/sequences.rb
@@ -6,6 +6,7 @@ module Zxcvbn
   module Matchers
     # Matches monotonically incrementing or decrementing character sequences,
     # such as "abcde", "54321", or "ZYXW".
+    # @api private
     class Sequences
       # Maximum absolute step between adjacent characters for a valid sequence.
       MAX_DELTA  = 5

--- a/lib/zxcvbn/matchers/spatial.rb
+++ b/lib/zxcvbn/matchers/spatial.rb
@@ -6,6 +6,7 @@ module Zxcvbn
   module Matchers
     # Matches keyboard spatial patterns (e.g. "qwerty", "asdf") across all
     # configured adjacency graphs.
+    # @api private
     class Spatial
       # Matches characters that require the Shift key on a standard keyboard.
       SHIFTED_RX = /[~!@#$%^&*()_+QWERTYUIOP{}|ASDFGHJKL:"ZXCVBNM<>?]/

--- a/lib/zxcvbn/matchers/year.rb
+++ b/lib/zxcvbn/matchers/year.rb
@@ -5,6 +5,7 @@ require 'zxcvbn/matchers/regex_helpers'
 module Zxcvbn
   module Matchers
     # Matches 4-digit year substrings (1900–2019) in the password.
+    # @api private
     class Year
       include RegexHelpers
 

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -17,6 +17,7 @@ module Zxcvbn
   # Includes dictionary, l33t, spatial, digit, repeat, sequence, year, date,
   # and reverse-dictionary matchers. User-supplied word lists are wrapped in
   # transient matchers for each call to {#matches}.
+  # @api private
   class Omnimatch
     # @param data [Data] loaded frequency lists and adjacency graphs
     def initialize(data)

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -7,6 +7,7 @@ require 'zxcvbn/scorer'
 
 module Zxcvbn
   # Analyses a single password and returns a {Score}.
+  # @api private
   class PasswordStrength
     # @param data [Data] loaded frequency lists and adjacency graphs
     def initialize(data)

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -8,6 +8,7 @@ require 'zxcvbn/match_builder'
 module Zxcvbn
   # Finds the match sequence that minimises the total number of guesses
   # required to crack a password, using dynamic programming.
+  # @api private
   class Scorer
     include Guesses
     include CrackTime

--- a/lib/zxcvbn/trie.rb
+++ b/lib/zxcvbn/trie.rb
@@ -5,6 +5,7 @@ module Zxcvbn
   # Provides fast prefix-based lookups to eliminate unnecessary substring checks.
   #
   # @see https://en.wikipedia.org/wiki/Trie
+  # @api private
   class Trie
     # Build a trie from a ranked dictionary hash.
     # @param ranked_dictionary [Hash{String => Integer}] word → rank


### PR DESCRIPTION
## Context

The library has a narrow public API (`Zxcvbn.test`, `Tester`, `Score`, `Match`, `Feedback`, `VERSION`) but many implementation classes are visible to documentation generators and can be mistaken for a supported interface.

`DATA_PATH` is also public, leaking the gem's internal file layout to callers.

## Changes

- Add `# @api private` YARD tags to all internal classes and modules: `PasswordStrength`, `Omnimatch`, `Scorer`, `Data`, `DictionaryRanker`, `Trie`, `MatchBuilder`, `Guesses`, `CrackTime`, `FeedbackGiver`, `Clock`, `Matchers`, and all eight matcher classes (`Date`, `Digits`, `Dictionary`, `Repeat`, `Spatial`, `Year`, `Sequences`, `L33t`, `RegexHelpers`).
- Add `private_constant :DATA_PATH` in `zxcvbn.rb`.

## Consequences

- YARD-generated docs will exclude internal classes from the public API surface.
- `Zxcvbn::DATA_PATH` raises `NameError` on direct reference (though `const_get` still works for code that genuinely needs it).
- No behaviour change; no public API is affected.