### PR TITLE
Raise ArgumentError for passwords over MAX_PASSWORD_LENGTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Repeat feedback now distinguishes single-char repeats (`"aaa"`) from multi-char repeats (`"abcabcabc"`), matching zxcvbn.js v4 ([#69])
  - `year` pattern matches now produce a "Recent years are easy to guess" warning ([#69])
  - Sole matches from the `english_wikipedia` dictionary now produce an "A word by itself is easy to guess" warning ([#69])
+ - **Breaking**: `Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than `Tester::MAX_PASSWORD_LENGTH` characters (default: 256). Previously, long passwords were accepted and could cause super-quadratic runtime on adversarial repeat inputs to the `password` argument. The `user_inputs` parameter remains unbounded. Override the limit by setting the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable before the gem loads.
 
 ### Removed
  - Support for Ruby versions below 3.3 ([#70])

--- a/README.md
+++ b/README.md
@@ -264,9 +264,12 @@ Subsequent calls reuse the already-loaded dictionaries, so `calc_time` is signif
 > [!WARNING]
 > Scoring time grows with password length. For adversarial inputs such as
 > short repeated sequences (e.g. `"ab" * 500`), the internal pattern-matching
-> DP produces super-quadratic runtime. Enforce a password length limit
-> appropriate for your use case before calling `Zxcvbn.test` or
-> `Zxcvbn::Tester#test`.
+> DP produces super-quadratic runtime. Both `Zxcvbn.test` and
+> `Zxcvbn::Tester#test` raise `Zxcvbn::PasswordTooLong` for passwords longer
+> than `Tester::MAX_PASSWORD_LENGTH` characters (default: 256). Override the
+> limit with the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable, but be
+> aware that raising it re-exposes this runtime risk. The `user_inputs`
+> parameter is not length-bounded; apply your own limit to those values.
 
 > [!WARNING]
 > Storing the guesses or score for an encrypted or hashed value provides
@@ -381,6 +384,36 @@ match.dictionary_name == "english_wikipedia"
 If you pass a `word_lists` argument to `Zxcvbn.test` or `Tester#add_word_lists`, update any `"english"` key to `"english_wikipedia"` to keep custom entries in the same namespace as the built-in list.
 
 A new `us_tv_and_film` frequency list has also been added. Update any `dictionary_name` allowlists or case statements to include it.
+
+### Password length limit
+
+`Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than `Tester::MAX_PASSWORD_LENGTH` characters (default: 256). Previously, long passwords were accepted without error. The `user_inputs` parameter remains unbounded.
+
+If your application accepts user-controlled input longer than 256 characters, either add a length check before calling the gem, construct a `Tester` with a custom limit, or adjust the process-wide default via the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable.
+
+To enforce your own limit before calling the gem (note: bcrypt's limit is 72 **bytes**, not characters):
+
+```ruby
+raise ArgumentError, "Password too long" if password.bytesize > 72 # bcrypt's 72-byte limit
+result = Zxcvbn.test(password)
+```
+
+To use a different limit for a specific tester without touching the environment:
+
+```ruby
+tester = Zxcvbn::Tester.new(max_password_length: 128)
+result = tester.test(password)
+```
+
+To adjust the process-wide default, set the environment variable **before the process starts** — the default is captured once when the gem loads and cannot be changed at runtime:
+
+```sh
+ZXCVBN_MAX_PASSWORD_LENGTH=1024 bundle exec rails server
+```
+
+In Rails, set it via the process environment (e.g. a `.env` file read by your process manager), not in `config/initializers/` — initializers run after `Bundler.require` loads the gem, so setting the env var there has no effect.
+
+Or export it from your shell profile, process manager, or platform environment config (Heroku, Docker, etc.). Note that raising the limit re-exposes the super-quadratic runtime for adversarial inputs to the `password` argument.
 
 ### Score values will change
 

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -27,11 +27,10 @@ module Zxcvbn
   # this is equivalent to using {Tester} directly. When +word_lists+ are
   # provided, a fresh {Tester} is constructed each call.
   #
-  # Scoring time grows with password length: the DP is O(n × m) where n is
-  # the password length and m is the number of pattern matches. For
-  # adversarial inputs such as short repeated sequences (e.g. "ab" * 500),
-  # m also grows with n, producing super-quadratic runtime. Enforce a
-  # password length limit appropriate for your use case before calling this.
+  # Raises {PasswordTooLong} (a subclass of +ArgumentError+) if the password
+  # exceeds +Tester::MAX_PASSWORD_LENGTH+ characters (default: 256). Override
+  # process-wide by setting +ZXCVBN_MAX_PASSWORD_LENGTH+ before the gem loads;
+  # for per-call limits, use {Tester} directly with +max_password_length:+.
   #
   # Example:
   #

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -4,6 +4,11 @@ require 'zxcvbn/data'
 require 'zxcvbn/password_strength'
 
 module Zxcvbn
+  # Raised when a password exceeds {Tester::MAX_PASSWORD_LENGTH} characters.
+  # Inherits from +ArgumentError+ for backward compatibility with existing
+  # +rescue ArgumentError+ clauses.
+  class PasswordTooLong < ArgumentError; end
+
   # Allows you to test the strength of multiple passwords without reading and
   # parsing the dictionary data from disk each test. Dictionary data is read
   # once from disk and stored in memory for the life of the Tester object.
@@ -18,22 +23,52 @@ module Zxcvbn
   #   tester.test("password 2")
   #   tester.test("password 3")
   class Tester
-    def initialize
+    # Default maximum password length when no +max_password_length:+ is given
+    # to {#initialize}. Passwords longer than this raise {PasswordTooLong}.
+    # Defaults to 256; override process-wide by setting the
+    # +ZXCVBN_MAX_PASSWORD_LENGTH+ environment variable before the gem loads,
+    # or per-instance via <tt>Tester.new(max_password_length: n)</tt>.
+    MAX_PASSWORD_LENGTH = begin
+      Integer(ENV.fetch('ZXCVBN_MAX_PASSWORD_LENGTH', 256))
+    rescue ArgumentError, TypeError
+      raise ArgumentError,
+            'ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; ' \
+            "got #{ENV['ZXCVBN_MAX_PASSWORD_LENGTH'].inspect}"
+    end
+
+    unless MAX_PASSWORD_LENGTH.positive?
+      raise ArgumentError,
+            "ZXCVBN_MAX_PASSWORD_LENGTH must be positive; got #{MAX_PASSWORD_LENGTH}"
+    end
+
+    # @param max_password_length [Integer] passwords longer than this raise
+    #   {PasswordTooLong} from {#test}. Defaults to {MAX_PASSWORD_LENGTH}.
+    def initialize(max_password_length: MAX_PASSWORD_LENGTH)
+      unless max_password_length.is_a?(Integer) && max_password_length.positive?
+        raise ArgumentError,
+              "max_password_length must be a positive integer; got #{max_password_length.inspect}"
+      end
+
       @data = Data.new
+      @max_password_length = max_password_length
     end
 
     # Evaluates a password and returns a {Score}.
     #
-    # Scoring time grows with password length: the DP is O(n × m) where n is
-    # the password length and m is the number of pattern matches. For
-    # adversarial inputs such as short repeated sequences (e.g. "ab" * 500),
-    # m also grows with n, producing super-quadratic runtime. Enforce a
-    # password length limit appropriate for your use case before calling this.
+    # Raises {PasswordTooLong} if the password exceeds the +max_password_length+
+    # passed to {#initialize} (default: {MAX_PASSWORD_LENGTH}). The limit exists
+    # because scoring time grows super-quadratically on adversarial inputs such
+    # as short repeated sequences (e.g. <tt>"ab" * 500</tt>).
     #
     # @param password [String] the password to evaluate
     # @param user_inputs [Array<String>] caller-supplied words to treat as known
     # @return [Score]
+    # @raise [PasswordTooLong] if the password exceeds the maximum length
     def test(password, user_inputs = [])
+      if password && password.length > @max_password_length
+        raise PasswordTooLong,
+              "Password exceeds the maximum length of #{@max_password_length}."
+      end
       PasswordStrength.new(@data).test(password, sanitize(user_inputs))
     end
 

--- a/sig/zxcvbn.rbs
+++ b/sig/zxcvbn.rbs
@@ -1,4 +1,7 @@
 module Zxcvbn
+  class PasswordTooLong < ArgumentError
+  end
+
   VERSION: String
 
   DATA_PATH: Pathname

--- a/sig/zxcvbn/tester.rbs
+++ b/sig/zxcvbn/tester.rbs
@@ -1,8 +1,10 @@
 module Zxcvbn
   class Tester
+    MAX_PASSWORD_LENGTH: Integer
+
     @data: Data
 
-    def initialize: () -> void
+    def initialize: (?max_password_length: Integer) -> void
 
     def test: (String? password, ?Array[untyped] user_inputs) -> Score
 

--- a/spec/zxcvbn/tester_spec.rb
+++ b/spec/zxcvbn/tester_spec.rb
@@ -114,27 +114,49 @@ RSpec.describe Zxcvbn::Tester do
   end
 
   context 'with a very long password' do
-    it 'scores the full password without truncation' do
-      long = 'a' * 400
-      result = tester.test(long)
-      expect(result.password.length).to eq 400
+    it 'accepts passwords at the length limit' do
+      at_limit = 'a' * Zxcvbn::Tester::MAX_PASSWORD_LENGTH
+      expect { tester.test(at_limit) }.not_to raise_error
     end
 
-    it 'completes in reasonable time for adversarial repeat inputs' do
-      adversarial = 'ab' * 128
+    it 'raises PasswordTooLong for passwords over the length limit' do
+      over_limit = 'a' * (Zxcvbn::Tester::MAX_PASSWORD_LENGTH + 1)
+      expect { tester.test(over_limit) }.to raise_error(Zxcvbn::PasswordTooLong, /exceeds the maximum length of/)
+    end
+
+    it 'completes in reasonable time for adversarial repeat inputs at the limit' do
+      adversarial = 'ab' * (Zxcvbn::Tester::MAX_PASSWORD_LENGTH / 2)
       elapsed = Benchmark.realtime { tester.test(adversarial) }
       expect(elapsed).to be < 5
     end
 
-    it 'produces finite crack times for passwords longer than 308 characters' do
+    it 'produces finite crack times when the limit is raised past 308 characters' do
       # 'z' * 400 hits the repeat matcher (guesses ~4801), not bruteforce.
       # Use a high-entropy string so the whole password is a single bruteforce
-      # match: length 400 → 10**400 → Float::MAX → crack time overflows to Infinity.
+      # match: length 400 → 10**400 → Float::MAX → crack time overflows to Infinity
+      # without the clamp.
+      high_limit_tester = Zxcvbn::Tester.new(max_password_length: 400)
       saved = srand(7)
       high_entropy = (1..400).map { rand(33..126).chr }.join
       srand(saved)
-      result = tester.test(high_entropy)
+      result = high_limit_tester.test(high_entropy)
       expect(result.crack_times_seconds.values).to all(be_finite)
+    end
+  end
+
+  context 'with a custom max_password_length' do
+    let(:tester) { Zxcvbn::Tester.new(max_password_length: 10) }
+
+    it 'accepts passwords at the custom limit' do
+      expect { tester.test('a' * 10) }.not_to raise_error
+    end
+
+    it 'raises PasswordTooLong for passwords over the custom limit' do
+      expect { tester.test('a' * 11) }.to raise_error(Zxcvbn::PasswordTooLong)
+    end
+
+    it 'raises ArgumentError for non-positive max_password_length' do
+      expect { Zxcvbn::Tester.new(max_password_length: 0) }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/zxcvbn_spec.rb
+++ b/spec/zxcvbn_spec.rb
@@ -23,4 +23,16 @@ RSpec.describe 'Zxcvbn.test' do
       expect(result.guesses).to_not be_nil
     end
   end
+
+  context 'with a password over the length limit' do
+    let(:over_limit) { 'a' * (Zxcvbn::Tester::MAX_PASSWORD_LENGTH + 1) }
+
+    it 'raises PasswordTooLong via the shared default tester' do
+      expect { Zxcvbn.test(over_limit) }.to raise_error(Zxcvbn::PasswordTooLong)
+    end
+
+    it 'raises PasswordTooLong via a fresh tester when word_lists are supplied' do
+      expect { Zxcvbn.test(over_limit, [], { 'custom' => ['word'] }) }.to raise_error(Zxcvbn::PasswordTooLong)
+    end
+  end
 end


### PR DESCRIPTION
## Context

Scoring time in zxcvbn-ruby grows super-quadratically on adversarial inputs — short repeated sequences like `"ab" * 500` cause the internal DP to run for tens of seconds. The gem accepts passwords of any length, relying on callers to enforce a limit. In practice this is easy to miss, and a single unguarded endpoint is enough to exhaust a Puma/Unicorn worker pool.

## Changes

Introduces a fail-loud password length cap with a named exception class and per-instance override support.

- Introduces `Zxcvbn::PasswordTooLong < ArgumentError`, raised when a password exceeds the configured limit
- `Tester#test` and `Zxcvbn.test` raise `PasswordTooLong` for passwords over `Tester::MAX_PASSWORD_LENGTH` (default: 256 characters)
- `Tester.new` accepts a `max_password_length:` keyword for per-instance limits, overriding the process-wide default for that tester
- `MAX_PASSWORD_LENGTH` defaults to 256; overridable process-wide via `ZXCVBN_MAX_PASSWORD_LENGTH` before the gem loads — the env var is now validated at load time and raises with a message naming the env var if the value is missing, non-integer, or non-positive
- Documents the change in the README warning box, migration guide, CHANGELOG, YARD docs, and RBS signatures
- The `user_inputs` parameter is not bounded by this change; the README and CHANGELOG now say so explicitly

## Consequences

- Callers passing passwords longer than 256 characters now receive `Zxcvbn::PasswordTooLong` instead of a slow result; existing `rescue ArgumentError` clauses continue to work unchanged since `PasswordTooLong` is a subclass
- Callers that need a different limit can pass `max_password_length:` to `Tester.new`, or set `ZXCVBN_MAX_PASSWORD_LENGTH` in the process environment before the gem loads — setting it in a Rails initializer has no effect (the gem is loaded first by Bundler)
- Callers passing passwords through `Zxcvbn.test` directly cannot set a per-call limit; use `Tester` directly for that