### PR TITLE
Fix date matcher using `Time.now.year` instead of shared `reference_year`

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -57,6 +57,7 @@ Metrics/MethodLength:
     - 'lib/zxcvbn/matchers/sequences.rb'
     - 'lib/zxcvbn/matchers/spatial.rb'
     - 'lib/zxcvbn/omnimatch.rb'
+    - 'lib/zxcvbn/password_strength.rb'
     - 'lib/zxcvbn/scorer.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne.

--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -35,10 +35,12 @@ module Zxcvbn
       # whose character span is fully contained within another match's span.
       #
       # @param password [String] the password to search
+      # @param reference_year [Integer] year used to pick the closest candidate for
+      #   separator-free dates; defaults to the current year
       # @return [Array<MatchBuilder>] matches with pattern 'date', each containing
       #   +year+, +month+, +day+, and +separator+
-      def matches(password)
-        all = match_with_separator(password) + match_without_separator(password)
+      def matches(password, reference_year: Time.now.year)
+        all = match_with_separator(password) + match_without_separator(password, reference_year:)
         all.reject do |match|
           all.any? { |other| !other.equal?(match) && other.i <= match.i && other.j >= match.j }
         end
@@ -85,8 +87,10 @@ module Zxcvbn
       # are skipped to avoid treating a year token as a date.
       #
       # @param password [String] the password to search
+      # @param reference_year [Integer] year used to pick the closest candidate;
+      #   defaults to the current year
       # @return [Array<MatchBuilder>] separator-free date matches
-      def match_without_separator(password)
+      def match_without_separator(password, reference_year: Time.now.year)
         result = []
         return result if password.length < 4
 
@@ -104,7 +108,6 @@ module Zxcvbn
             end
             next if candidates.empty?
 
-            reference_year = Time.now.year
             best = candidates.min_by { |c| (c[:year] - reference_year).abs }
 
             result << MatchBuilder.new(

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -29,10 +29,19 @@ module Zxcvbn
     #
     # @param password [String] the password to analyse
     # @param user_inputs [Array<String>] caller-supplied words to add as a dictionary
+    # @param reference_year [Integer] year used by the date matcher to pick the closest
+    #   candidate; shared with the scorer so both phases agree even across midnight
     # @return [Array<MatchBuilder>]
-    def matches(password, user_inputs = [])
+    def matches(password, user_inputs = [], reference_year: Time.now.year)
       matchers = @matchers + user_input_matchers(user_inputs)
-      all_matches = matchers.map { |matcher| matcher.matches(password) }.inject(&:+)
+      all_matches = matchers.flat_map do |matcher|
+        case matcher
+        when Matchers::Date
+          matcher.matches(password, reference_year:)
+        else
+          matcher.matches(password)
+        end
+      end
       all_matches + reverse_dictionary_matches(password, user_inputs)
     end
 

--- a/lib/zxcvbn/password_strength.rb
+++ b/lib/zxcvbn/password_strength.rb
@@ -24,7 +24,8 @@ module Zxcvbn
       password ||= ''
       result = nil
       calc_time = Clock.realtime do
-        matches = @omnimatch.matches(password, user_inputs)
+        reference_year = @scorer.reference_year
+        matches = @omnimatch.matches(password, user_inputs, reference_year:)
         result = @scorer.most_guessable_match_sequence(password, matches)
       end
       result.with(

--- a/sig/zxcvbn/omnimatch.rbs
+++ b/sig/zxcvbn/omnimatch.rbs
@@ -5,7 +5,7 @@ module Zxcvbn
 
     def initialize: (Data data) -> void
 
-    def matches: (String password, ?Array[String] user_inputs) -> Array[MatchBuilder]
+    def matches: (String password, ?Array[String] user_inputs, ?reference_year: Integer) -> Array[MatchBuilder]
 
     private
 

--- a/spec/zxcvbn/matchers/date_spec.rb
+++ b/spec/zxcvbn/matchers/date_spec.rb
@@ -165,6 +165,29 @@ RSpec.describe Zxcvbn::Matchers::Date do
       expect(full).not_to be_nil
       expect(full.year).to eq 1997
     end
+
+    it 'uses the supplied reference_year, not Time.now, to pick the closest candidate' do
+      # "1285" splits into candidates: year=1985 (2-digit "85"→1985) and year=2005 (2-digit "05"→2005).
+      # reference_year near 1990 picks 1985; reference_year near 2020 picks 2005.
+      matches_past = matcher.match_without_separator('1285', reference_year: 1990)
+      matches_recent = matcher.match_without_separator('1285', reference_year: 2020)
+      full_past = matches_past.find { |m| m.token == '1285' }
+      full_recent = matches_recent.find { |m| m.token == '1285' }
+      expect(full_past.year).to be < 2000
+      expect(full_recent.year).to be >= 2000
+    end
+  end
+
+  describe '#matches reference_year threading' do
+    it 'uses the supplied reference_year rather than Time.now.year' do
+      allow(Time).to receive(:now).and_return(double(year: 9999))
+      # "1285" has candidates 1985 and 2005. With reference_year=1990, year 1985 wins.
+      # If Time.now leaked through it would return 9999 and year 2005 would win instead.
+      results = matcher.matches('1285', reference_year: 1990)
+      full = results.find { |m| m.token == '1285' }
+      expect(full).not_to be_nil
+      expect(full.year).to be < 2000
+    end
   end
 
   context 'invalid date' do


### PR DESCRIPTION
## Context

`Guesses#reference_year` memoises `Time.now.year` on the scorer instance so the year stays stable for the duration of a scoring run. The date matcher calls `Time.now.year` directly inside its per-substring loop, independently of the scorer. A run that crosses midnight can therefore see different years in the match phase and the score phase — the bug PR #91 claimed to fix is only half-fixed. The call also incurs a system call on every substring iteration.

## Changes

- `Matchers::Date#matches` and `#match_without_separator` accept a `reference_year:` keyword argument (defaults to `Time.now.year` for standalone use)
- `Omnimatch#matches` accepts `reference_year:` and forwards it to the date matcher
- `PasswordStrength#test` captures `reference_year` from the scorer before calling `Omnimatch#matches`, so both phases share the same value
- Two specs added to `date_spec.rb`: one asserting `match_without_separator` respects the supplied year when choosing between century-ambiguous candidates, one asserting `matches` uses the supplied year rather than `Time.now`

## Consequences

Match and score phases always agree on the year within a single `test` call, even across midnight. The repeated `Time.now` system call per substring is eliminated.