### PR TITLE
Add missing RBS signatures and fix stale declarations

### DIFF
--- a/lib/zxcvbn/clock.rb
+++ b/lib/zxcvbn/clock.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Zxcvbn
-  # Monotonic-clock utility for measuring elapsed wall time.
+  # Monotonic-clock utility for measuring elapsed time.
   # @api private
   module Clock
     # Yields to the block and returns the elapsed time in seconds.

--- a/lib/zxcvbn/matchers/regex_helpers.rb
+++ b/lib/zxcvbn/matchers/regex_helpers.rb
@@ -14,7 +14,7 @@ module Zxcvbn
       #
       # @param regex [Regexp] pattern to search for
       # @param password [String] the password to search
-      # @yieldparam match [Match] match with i, j, and token set
+      # @yieldparam match [MatchBuilder] match with i, j, and token set
       # @yieldparam re_match [MatchData] the underlying MatchData object
       # @return [void]
       def re_match_all(regex, password)

--- a/lib/zxcvbn/score.rb
+++ b/lib/zxcvbn/score.rb
@@ -6,7 +6,7 @@ module Zxcvbn
   # @!attribute [r] password
   #   @return [String] the password that was evaluated
   # @!attribute [r] guesses
-  #   @return [Integer] estimated number of guesses to crack the password
+  #   @return [Numeric] estimated number of guesses to crack the password
   # @!attribute [r] sequence
   #   @return [Array<Match>] the optimal match sequence
   # @!attribute [r] crack_times_seconds

--- a/sig/zxcvbn/clock.rbs
+++ b/sig/zxcvbn/clock.rbs
@@ -1,0 +1,5 @@
+module Zxcvbn
+  module Clock
+    def self.realtime: () { () -> void } -> Float
+  end
+end

--- a/sig/zxcvbn/data.rbs
+++ b/sig/zxcvbn/data.rbs
@@ -35,8 +35,6 @@ module Zxcvbn
 
     def build_tries: (Hash[String, ranked_dictionary] ranked) -> Hash[String, Trie]
 
-    def build_trie: (ranked_dictionary ranked_dictionary) -> Trie
-
     def compute_graph_stats: () -> graph_stats
   end
 end

--- a/sig/zxcvbn/feedback.rbs
+++ b/sig/zxcvbn/feedback.rbs
@@ -4,5 +4,7 @@ module Zxcvbn
     attr_reader suggestions: Array[String]
 
     def initialize: (?warning: String, ?suggestions: Array[String]) -> void
+
+    def with: (?warning: String, ?suggestions: Array[String]) -> Feedback
   end
 end

--- a/sig/zxcvbn/matchers/date.rbs
+++ b/sig/zxcvbn/matchers/date.rbs
@@ -1,0 +1,25 @@
+module Zxcvbn
+  module Matchers
+    class Date
+      MAYBE_DATE_WITH_SEP: Regexp
+      MAYBE_DATE_WITHOUT_SEP: Regexp
+      DATE_SPLITS: Hash[Integer, Array[[Integer, Integer]]]
+      DATE_MIN_YEAR: Integer
+      DATE_MAX_YEAR: Integer
+
+      def matches: (String password, ?reference_year: Integer) -> Array[MatchBuilder]
+
+      def match_with_separator: (String password) -> Array[MatchBuilder]
+
+      def match_without_separator: (String password, ?reference_year: Integer) -> Array[MatchBuilder]
+
+      def map_ints_to_dmy: (Integer int1, Integer int2, Integer int3) -> { year: Integer, month: Integer, day: Integer }?
+
+      def map_ints_to_dm: (Integer day_val, Integer month_val) -> { day: Integer, month: Integer }?
+
+      def matches_year?: (String token) -> bool
+
+      def expand_year: (Integer year) -> Integer
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/dictionary.rbs
+++ b/sig/zxcvbn/matchers/dictionary.rbs
@@ -1,0 +1,21 @@
+module Zxcvbn
+  module Matchers
+    class Dictionary
+      @name: String
+      @ranked_dictionary: Data::ranked_dictionary
+      @trie: Trie?
+
+      def initialize: (String name, Data::ranked_dictionary ranked_dictionary, ?Trie? trie) -> void
+
+      def matches: (String password) -> Array[MatchBuilder]
+
+      private
+
+      def trie_matches: (String password, String lowercased_password) -> Array[MatchBuilder]
+
+      def hash_matches: (String password, String lowercased_password) -> Array[MatchBuilder]
+
+      def build_match: (String matched_word, String token, Integer start_pos, Integer end_pos, Integer rank) -> MatchBuilder
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/digits.rbs
+++ b/sig/zxcvbn/matchers/digits.rbs
@@ -1,0 +1,11 @@
+module Zxcvbn
+  module Matchers
+    class Digits
+      include RegexHelpers
+
+      DIGITS_REGEX: Regexp
+
+      def matches: (String password) -> Array[MatchBuilder]
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/l33t.rbs
+++ b/sig/zxcvbn/matchers/l33t.rbs
@@ -1,0 +1,27 @@
+module Zxcvbn
+  module Matchers
+    class L33t
+      L33T_TABLE: Hash[String, Array[String]]
+
+      @dictionary_matchers: Array[Dictionary]
+
+      def initialize: (Array[Dictionary] dictionary_matchers) -> void
+
+      def matches: (String password) -> Array[MatchBuilder]
+
+      def translate: (String password, Hash[String, String] sub) -> String
+
+      def relevent_l33t_subtable: (String password) -> Hash[String, Array[String]]
+
+      def l33t_subs: (Hash[String, Array[String]] table) -> Array[Hash[String, String]]
+
+      private
+
+      def process_match: (MatchBuilder match, String password, Hash[String, String] substitution, Array[MatchBuilder] matches) -> void
+
+      def find_substitutions: (Array[untyped] subs, Hash[String, Array[String]] table, Array[String] keys) -> Array[untyped]
+
+      def dedup: (Array[untyped] subs) -> Array[untyped]
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/regex_helpers.rbs
+++ b/sig/zxcvbn/matchers/regex_helpers.rbs
@@ -1,0 +1,7 @@
+module Zxcvbn
+  module Matchers
+    module RegexHelpers
+      def re_match_all: (Regexp regex, String password) { (MatchBuilder, MatchData) -> void } -> void
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/repeat.rbs
+++ b/sig/zxcvbn/matchers/repeat.rbs
@@ -1,0 +1,11 @@
+module Zxcvbn
+  module Matchers
+    class Repeat
+      GREEDY: Regexp
+      LAZY: Regexp
+      LAZY_ANCHORED: Regexp
+
+      def matches: (String password) -> Array[MatchBuilder]
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/sequences.rbs
+++ b/sig/zxcvbn/matchers/sequences.rbs
@@ -1,0 +1,16 @@
+module Zxcvbn
+  module Matchers
+    class Sequences
+      MAX_DELTA: Integer
+      ALL_LOWER: Regexp
+      ALL_UPPER: Regexp
+      ALL_DIGITS: Regexp
+
+      def matches: (String password) -> Array[MatchBuilder]
+
+      private
+
+      def classify: (String token) -> [String, Integer]
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/spatial.rbs
+++ b/sig/zxcvbn/matchers/spatial.rbs
@@ -1,0 +1,15 @@
+module Zxcvbn
+  module Matchers
+    class Spatial
+      SHIFTED_RX: Regexp
+
+      @graphs: Hash[String, Data::adjacency_graph]
+
+      def initialize: (Hash[String, Data::adjacency_graph] graphs) -> void
+
+      def matches: (String password) -> Array[MatchBuilder]
+
+      def matches_for_graph: (Data::adjacency_graph graph, String graph_name, String password) -> Array[MatchBuilder]
+    end
+  end
+end

--- a/sig/zxcvbn/matchers/year.rbs
+++ b/sig/zxcvbn/matchers/year.rbs
@@ -1,0 +1,11 @@
+module Zxcvbn
+  module Matchers
+    class Year
+      include RegexHelpers
+
+      YEAR_REGEX: Regexp
+
+      def matches: (String password) -> Array[MatchBuilder]
+    end
+  end
+end

--- a/sig/zxcvbn/trie.rbs
+++ b/sig/zxcvbn/trie.rbs
@@ -4,6 +4,8 @@ module Zxcvbn
 
     @root: node
 
+    def self.from_ranked: (Data::ranked_dictionary ranked_dictionary) -> Trie
+
     def initialize: () -> void
 
     def insert: (String word, Integer rank) -> void


### PR DESCRIPTION
## Context

The sig/ directory is out of sync with lib/. All 9 matcher classes and the Clock module have no RBS coverage. The `build_trie` method was removed from lib/ (replaced by `Trie.from_ranked`) but its declaration remains in `data.rbs`. `Trie.from_ranked` is absent from `trie.rbs`. `Feedback#with` is absent from `feedback.rbs`, despite the other Data-derived classes having it declared. Several YARD docs in lib/ also have inaccurate types.

## Changes

- Add `sig/zxcvbn/clock.rbs`
- Add `sig/zxcvbn/matchers/` with RBS for all 9 matcher classes: `date`, `dictionary`, `digits`, `l33t`, `regex_helpers`, `repeat`, `sequences`, `spatial`, `year`
- Remove stale `build_trie` declaration from `data.rbs`
- Add `Trie.from_ranked` to `trie.rbs`
- Add `Feedback#with` to `feedback.rbs`
- Fix `Clock` class description: "wall time" → "elapsed time" (uses `CLOCK_MONOTONIC`, not wall clock)
- Fix `RegexHelpers#re_match_all` `@yieldparam`: typed as `Match` but yields `MatchBuilder`
- Fix `Score#guesses` `@return`: typed as `Integer` but value is always `Float`; aligns YARD with the existing `Numeric` declaration in the RBS

## Consequences

`rbs validate` passes clean. The sig/ directory now mirrors lib/ for all classes that have Ruby implementations. YARD types are consistent with the RBS declarations.