### PR TITLE
Remove dead `Date#matches_year?` method

### DIFF
--- a/lib/zxcvbn/matchers/date.rb
+++ b/lib/zxcvbn/matchers/date.rb
@@ -186,16 +186,6 @@ module Zxcvbn
         nil
       end
 
-      # Returns +true+ if +token+ is a 4-digit string that looks like a standalone
-      # year (matched by {Year::YEAR_REGEX}), used to avoid double-counting year
-      # tokens as no-separator dates.
-      #
-      # @param token [String] the token to test
-      # @return [Boolean]
-      def matches_year?(token)
-        token.size == 4 && Year::YEAR_REGEX.match?(token)
-      end
-
       # Expands a 2-digit year to 4 digits. Values above 99 are returned unchanged.
       # Mirrors +two_to_four_digit_year+ in the JS v4 source.
       #

--- a/sig/zxcvbn/matchers/date.rbs
+++ b/sig/zxcvbn/matchers/date.rbs
@@ -17,8 +17,6 @@ module Zxcvbn
 
       def map_ints_to_dm: (Integer day_val, Integer month_val) -> { day: Integer, month: Integer }?
 
-      def matches_year?: (String token) -> bool
-
       def expand_year: (Integer year) -> Integer
     end
   end

--- a/spec/zxcvbn/matchers/date_spec.rb
+++ b/spec/zxcvbn/matchers/date_spec.rb
@@ -88,20 +88,6 @@ RSpec.describe Zxcvbn::Matchers::Date do
     end
   end
 
-  describe '#matches_year?' do
-    it 'recognises years in the 1900–2019 range' do
-      expect(matcher.matches_year?('1999')).to be_truthy
-      expect(matcher.matches_year?('2009')).to be_truthy
-      expect(matcher.matches_year?('2019')).to be_truthy
-    end
-
-    it 'does not block tokens outside the year range' do
-      expect(matcher.matches_year?('2020')).to be_falsy
-      expect(matcher.matches_year?('2025')).to be_falsy
-      expect(matcher.matches_year?('1899')).to be_falsy
-    end
-  end
-
   describe '#expand_year' do
     {
       12 => 2012,


### PR DESCRIPTION
## Context

`Date#matches_year?` is a public method with zero internal callers. `match_without_separator` inlines the same logic directly: `token.length == 4 && Year::YEAR_REGEX.match?(token)`.

## Changes

- Remove `Date#matches_year?` from `lib/zxcvbn/matchers/date.rb`
- Remove its declaration from `sig/zxcvbn/matchers/date.rbs`
- Remove its specs from `spec/zxcvbn/matchers/date_spec.rb`

## Consequences

No behaviour change. The inline guard in `match_without_separator` is unchanged.