### PR TITLE
Expand parity test passwords to cover all feedback branches

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,5 +77,13 @@ TEST_PASSWORDS = [
   'chenlu0525',
   'rtrtrtrt',
   'my_new_password',
-  'Bilbo Baggin'
+  'Bilbo Baggin',
+
+  # Feedback branch coverage
+  '1997',         # year warning: "Recent years are easy to guess"
+  '3/13/1997',    # date warning: "Dates are often easy to guess"
+  'qaz',          # spatial turns=1: "Straight rows of keys are easy to guess"
+  'democracy',    # wikipedia sole match: "A word by itself is easy to guess"
+  'drowssap',     # reversed word suggestion
+  'jennifer'      # sole name: "Names and surnames by themselves are easy to guess"
 ].freeze


### PR DESCRIPTION
## Context

The JS parity test suite runs all `TEST_PASSWORDS` through both the Ruby gem and zxcvbn.js v4.4.2, asserting that score, guesses, match sequence, crack times, and feedback match. Several feedback warning and suggestion branches in `FeedbackGiver` are never exercised by the existing 42 passwords because no password in the list produces a match where those branches are the dominant feedback path.

The uncovered branches are:
- `"Recent years are easy to guess"` (year pattern)
- `"Dates are often easy to guess"` (date pattern)
- `"Straight rows of keys are easy to guess"` (spatial, `turns == 1`)
- `"A word by itself is easy to guess"` (english_wikipedia sole match)
- `"Reversed words aren't much harder to guess"` suggestion
- `"Names and surnames by themselves are easy to guess"` (sole name match)

## Changes

Six passwords added to `TEST_PASSWORDS` in `spec/spec_helper.rb`, each targeting a specific uncovered branch:

| Password | Branch covered |
|---|---|
| `'1997'` | year warning + "Avoid recent years" / "Avoid years that are associated with you" |
| `'3/13/1997'` | date warning + "Avoid dates and years that are associated with you" |
| `'qaz'` | spatial `turns == 1` warning |
| `'democracy'` | wikipedia sole-match warning |
| `'drowssap'` | reversed word suggestion |
| `'jennifer'` | sole name warning |

## Consequences

All previously uncovered `FeedbackGiver` warning and suggestion paths are now cross-validated against JS. The parity suite grows from 42 to 48 passwords with no failures.