### PR TITLE
Introduce TesterBuilder fluent API

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -59,6 +59,7 @@ Metrics/MethodLength:
     - 'lib/zxcvbn/omnimatch.rb'
     - 'lib/zxcvbn/scorer.rb'
     - 'lib/zxcvbn/tester.rb'
+    - 'lib/zxcvbn/tester_builder.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ModuleLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - User-input dictionary matchers now use the Trie path, preventing O(n²) slowdowns on long passwords ([#89])
 
 ### Added
+ - `Zxcvbn::TesterBuilder`: fluent builder for constructing a `Tester` with custom word lists and options. Obtain a builder via `Zxcvbn.tester`, then chain `add_word_list`, `max_password_length`, and `build`.
  - `Zxcvbn::Guesses` module with per-pattern guess estimation formulas matching zxcvbn.js v4: bruteforce, dictionary (with uppercase and l33t variation multipliers), spatial, repeat, sequence, digits, year, and date ([#69])
  - `us_tv_and_film` frequency list (19,160 entries) introduced in zxcvbn.js v4 ([#69])
  - Reverse dictionary matching in `Omnimatch` so reversed words (e.g. "drowssap") are detected and scored ([#69])
@@ -18,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - YARD documentation for all public classes, modules, and methods ([#72])
 
 ### Changed
+ - **Breaking**: `Zxcvbn::Tester.new` now requires `data:` and `max_password_length:` keyword arguments with no defaults. Use `Zxcvbn.tester.build` to construct a `Tester`.
  - **Breaking**: English frequency list dictionary name renamed from `english` to `english_wikipedia`, matching the zxcvbn.js source. Affects `match.dictionary_name` in results ([#90])
- - `Zxcvbn.test` now reuses a shared `Tester` instance across calls, avoiding repeated dictionary parsing. Equivalent to using `Tester` directly for callers who do not pass custom `word_lists` ([#80])
+ - `Zxcvbn.test` now reuses a shared `Tester` instance across calls, avoiding repeated dictionary parsing ([#80])
  - Repeat base tokens are now scored without `user_inputs`, matching zxcvbn.js v4. Previously, user-supplied words were propagated into the recursive scoring of a repeat's base token, causing repeat matches of user-supplied words to score lower than JS would report ([#83])
  - `Zxcvbn::Score` is now an immutable value object backed by Ruby's `Data`. Attribute setters (`calc_time=`, `feedback=`, etc.) have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#74])
  - **Breaking**: `Zxcvbn::Match` is now an immutable value object backed by Ruby's `Data`. Attribute setters have been removed. Instances now support structural equality (`==`/`eql?`/`hash`) and the `with` method for creating modified copies ([#92])
@@ -41,9 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Repeat feedback now distinguishes single-char repeats (`"aaa"`) from multi-char repeats (`"abcabcabc"`), matching zxcvbn.js v4 ([#69])
  - `year` pattern matches now produce a "Recent years are easy to guess" warning ([#69])
  - Sole matches from the `english_wikipedia` dictionary now produce an "A word by itself is easy to guess" warning ([#69])
- - **Breaking**: `Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than `Tester::MAX_PASSWORD_LENGTH` characters (default: 256). Previously, long passwords were accepted and could cause super-quadratic runtime on adversarial repeat inputs to the `password` argument. The `user_inputs` parameter remains unbounded. Override the limit by setting the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable before the gem loads.
+ - **Breaking**: `Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than 256 characters (the default). Previously, long passwords were accepted and could cause super-quadratic runtime on adversarial repeat inputs to the `password` argument. The `user_inputs` parameter remains unbounded. Override the limit with the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable or `Zxcvbn.tester.max_password_length(n).build`.
 
 ### Removed
+ - **Breaking**: `Tester#add_word_lists`. Use `Zxcvbn.tester.add_word_list(name, words).build` instead.
+ - **Breaking**: `word_lists:` argument to `Zxcvbn.test`. Use `Zxcvbn.tester.add_word_list(name, words).build` to construct a tester with custom word lists.
  - Support for Ruby versions below 3.3 ([#70])
 
 

--- a/README.md
+++ b/README.md
@@ -107,15 +107,15 @@ $ irb
  feedback=#<data Zxcvbn::Feedback warning="" suggestions=[]>>
 ```
 
-## Testing Multiple Passwords
+## Custom Testers
 
-The dictionaries used for password strength testing are loaded each request to `Zxcvbn.test`. If you you'd prefer to persist the dictionaries in memory (approx 20MB RSS) to perform lots of password tests in succession then you can use the `Zxcvbn::Tester` API:
+`Zxcvbn.test` reuses a shared `Tester` internally — dictionaries are loaded once and persist in memory. Use `Zxcvbn.tester.build` to construct a standalone `Tester` you control:
 
 ```ruby
 $ irb
 >> require 'zxcvbn'
 => true
->> tester = Zxcvbn::Tester.new
+>> tester = Zxcvbn.tester.build
 => #<Zxcvbn::Tester:0x3fe99d869aa4>
 >> pp tester.test('@lfred2004', ['alfred'])
 #<data Zxcvbn::Score
@@ -165,6 +165,15 @@ $ irb
      "Predictable substitutions like '@' instead of 'a' don't help very much"]>>
 ```
 
+To add custom word lists, chain `add_word_list` before `build`. Use a distinct name (e.g. `"company"`) — using a built-in name (`"english_wikipedia"`, `"passwords"`, `"female_names"`, `"male_names"`, `"surnames"`, `"us_tv_and_film"`) replaces that list entirely:
+
+```ruby
+>> tester = Zxcvbn.tester.add_word_list('company', %w[acme corp]).build
+=> #<Zxcvbn::Tester:0x3fe99d869bb8>
+>> tester.test('acme').score
+=> 0
+```
+
 Subsequent calls reuse the already-loaded dictionaries, so `calc_time` is significantly lower:
 
 ```ruby
@@ -177,7 +186,7 @@ Subsequent calls reuse the already-loaded dictionaries, so `calc_time` is signif
 > short repeated sequences (e.g. `"ab" * 500`), the internal pattern-matching
 > DP produces super-quadratic runtime. Both `Zxcvbn.test` and
 > `Zxcvbn::Tester#test` raise `Zxcvbn::PasswordTooLong` for passwords longer
-> than `Tester::MAX_PASSWORD_LENGTH` characters (default: 256). Override the
+> than 256 characters (the default). Override the
 > limit with the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable, but be
 > aware that raising it re-exposes this runtime risk. The `user_inputs`
 > parameter is not length-bounded; apply your own limit to those values.
@@ -292,13 +301,11 @@ match.dictionary_name == "english"
 match.dictionary_name == "english_wikipedia"
 ```
 
-If you pass a `word_lists` argument to `Zxcvbn.test` or `Tester#add_word_lists`, update any `"english"` key to `"english_wikipedia"` to keep custom entries in the same namespace as the built-in list.
-
 A new `us_tv_and_film` frequency list has also been added. Update any `dictionary_name` allowlists or case statements to include it.
 
 ### Password length limit
 
-`Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than `Tester::MAX_PASSWORD_LENGTH` characters (default: 256). Previously, long passwords were accepted without error. The `user_inputs` parameter remains unbounded.
+`Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than 256 characters (the default). Previously, long passwords were accepted without error. The `user_inputs` parameter remains unbounded.
 
 If your application accepts user-controlled input longer than 256 characters, either add a length check before calling the gem, construct a `Tester` with a custom limit, or adjust the process-wide default via the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable.
 
@@ -312,19 +319,43 @@ result = Zxcvbn.test(password)
 To use a different limit for a specific tester without touching the environment:
 
 ```ruby
-tester = Zxcvbn::Tester.new(max_password_length: 128)
+tester = Zxcvbn.tester.max_password_length(128).build
 result = tester.test(password)
 ```
 
-To adjust the process-wide default, set the environment variable **before the process starts** — the default is captured once when the gem loads and cannot be changed at runtime:
+To adjust the process-wide default, set `ZXCVBN_MAX_PASSWORD_LENGTH` in the process environment before the process starts:
 
 ```sh
 ZXCVBN_MAX_PASSWORD_LENGTH=1024 bundle exec rails server
 ```
 
-In Rails, set it via the process environment (e.g. a `.env` file read by your process manager), not in `config/initializers/` — initializers run after `Bundler.require` loads the gem, so setting the env var there has no effect.
+The variable is read when `TesterBuilder#build` is called. For the shared tester backing `Zxcvbn.test`, that is the first call to `Zxcvbn.test`.
 
 Or export it from your shell profile, process manager, or platform environment config (Heroku, Docker, etc.). Note that raising the limit re-exposes the super-quadratic runtime for adversarial inputs to the `password` argument.
+
+### Custom word lists
+
+`Tester#add_word_lists` and the `word_lists:` argument to `Zxcvbn.test` have been removed. Use the `Zxcvbn.tester` builder instead:
+
+```ruby
+# 1.x — no longer works
+result = Zxcvbn.test(password, user_inputs, word_lists: { 'company' => %w[acme corp] })
+tester.add_word_lists('company' => %w[acme corp])
+
+# 2.x
+tester = Zxcvbn.tester.add_word_list('company', %w[acme corp]).build
+result = tester.test(password, user_inputs)
+```
+
+`Zxcvbn::Tester.new` is no longer a public construction path — it now requires `data:` and `max_password_length:` keyword arguments with no defaults. Use `Zxcvbn.tester.build` (or the fluent builder) instead:
+
+```ruby
+# 1.x
+tester = Zxcvbn::Tester.new
+
+# 2.x
+tester = Zxcvbn.tester.build
+```
 
 ### Score values will change
 

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'pathname'
 require 'zxcvbn/version'
 require 'zxcvbn/tester'
+require 'zxcvbn/tester_builder'
 
 # Ruby port of zxcvbn.js — realistic password strength estimation.
 #
@@ -12,42 +12,50 @@ require 'zxcvbn/tester'
 module Zxcvbn
   module_function
 
-  # Path to the bundled data directory (frequency lists, adjacency graphs).
-  DATA_PATH = Pathname(File.expand_path('../data', __dir__))
-  private_constant :DATA_PATH
-
   # Mutex protecting lazy initialisation of the shared default {Tester}.
   DEFAULT_TESTER_MUTEX = Mutex.new
   private_constant :DEFAULT_TESTER_MUTEX
 
   # Returns a Zxcvbn::Score for the given password.
   #
-  # Reuses a shared {Tester} instance (with pre-loaded dictionaries) when no
-  # custom +word_lists+ are given. For repeated calls without custom word lists,
-  # this is equivalent to using {Tester} directly. When +word_lists+ are
-  # provided, a fresh {Tester} is constructed each call.
+  # Reuses a shared {Tester} instance across calls. For custom word lists or
+  # options, use {.tester} to build a dedicated {Tester}.
   #
   # Raises {PasswordTooLong} (a subclass of +ArgumentError+) if the password
-  # exceeds +Tester::MAX_PASSWORD_LENGTH+ characters (default: 256). Override
-  # process-wide by setting +ZXCVBN_MAX_PASSWORD_LENGTH+ before the gem loads;
-  # for per-call limits, use {Tester} directly with +max_password_length:+.
+  # exceeds the configured limit (default: 256 characters). Override process-wide
+  # via the +ZXCVBN_MAX_PASSWORD_LENGTH+ environment variable; for per-call limits,
+  # use {.tester} with {TesterBuilder#max_password_length}.
   #
   # Example:
   #
   #   Zxcvbn.test("password").score #=> 0
-  def test(password, user_inputs = [], word_lists = {})
-    if word_lists.empty?
-      default_tester.test(password, user_inputs)
-    else
-      tester = Tester.new
-      tester.add_word_lists(word_lists)
-      tester.test(password, user_inputs)
-    end
+  #
+  # @param password [String] the password to evaluate
+  # @param user_inputs [Array<String>] caller-supplied words to treat as known
+  # @return [Score]
+  # @raise [PasswordTooLong] if the password exceeds the maximum length
+  def test(password, user_inputs = [])
+    default_tester.test(password, user_inputs)
+  end
+
+  # Returns a new {TesterBuilder} for constructing a {Tester} with custom
+  # word lists and options.
+  #
+  # Example:
+  #
+  #   tester = Zxcvbn.tester
+  #     .add_word_list('company', %w[acme corp])
+  #     .max_password_length(75)
+  #     .build
+  #
+  # @return [TesterBuilder]
+  def tester
+    TesterBuilder.new
   end
 
   # @return [Tester] the shared default tester, constructed on first call
   def default_tester
-    DEFAULT_TESTER_MUTEX.synchronize { @default_tester ||= Tester.new }
+    DEFAULT_TESTER_MUTEX.synchronize { @default_tester ||= tester.build }
   end
   private_class_method :default_tester
 end

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
+require 'pathname'
 require 'zxcvbn/dictionary_ranker'
 require 'zxcvbn/trie'
 
@@ -14,14 +15,12 @@ module Zxcvbn
   #   their tries; use this for concurrent reads to guarantee the pair is always in sync
   # @api private
   class Data
-    # Consistent snapshot of ranked dictionaries and their tries.
-    # Stored as a single reference so it can be swapped atomically on update.
+    DATA_PATH = Pathname(File.expand_path('../../data', __dir__))
+    private_constant :DATA_PATH
+
+    # Consistent named pair of ranked dictionaries and their tries.
     Dictionaries = ::Data.define(:ranked, :tries)
     private_constant :Dictionaries
-
-    # Mutex serialising concurrent calls to {#add_word_list}.
-    WRITE_MUTEX = Mutex.new
-    private_constant :WRITE_MUTEX
 
     # Loads all built-in frequency lists and adjacency graphs from disk.
     def initialize
@@ -48,23 +47,16 @@ module Zxcvbn
 
     # Adds a custom word list and builds a trie for it.
     #
-    # Safe to call concurrently with {#dictionaries} reads and with other
-    # {#add_word_list} calls. The mutex serialises writers; the atomic reference
-    # swap ensures readers always observe a consistent ranked/tries pair.
-    #
     # @param name [String] dictionary name (used as a key in {#ranked_dictionaries})
     # @param list [Array<String>] ordered words (most common first)
     # @return [void]
     def add_word_list(name, list)
-      ranked_dict = DictionaryRanker.rank_dictionary(list)
+      ranked_dict = DictionaryRanker.rank_dictionary(list.select { |w| w.respond_to?(:downcase) })
       trie = Trie.from_ranked(ranked_dict)
-      WRITE_MUTEX.synchronize do
-        old = @dictionaries
-        @dictionaries = Dictionaries.new(
-          ranked: old.ranked.merge(name => ranked_dict),
-          tries: old.tries.merge(name => trie)
-        )
-      end
+      @dictionaries = @dictionaries.with(
+        ranked: @dictionaries.ranked.merge(name => ranked_dict),
+        tries: @dictionaries.tries.merge(name => trie)
+      )
     end
 
     private

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -33,6 +33,7 @@ module Zxcvbn
     #   candidate; shared with the scorer so both phases agree even across midnight
     # @return [Array<MatchBuilder>]
     def matches(password, user_inputs = [], reference_year: Time.now.year)
+      user_inputs = user_inputs.select { |i| i.respond_to?(:downcase) }
       matchers = @matchers + user_input_matchers(user_inputs)
       all_matches = matchers.flat_map do |matcher|
         case matcher

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -1,84 +1,65 @@
 # frozen_string_literal: true
 
 require 'zxcvbn/clock'
-require 'zxcvbn/data'
 require 'zxcvbn/feedback_giver'
 require 'zxcvbn/omnimatch'
 require 'zxcvbn/scorer'
 
 module Zxcvbn
-  # Raised when a password exceeds {Tester::MAX_PASSWORD_LENGTH} characters.
+  # Raised when a password exceeds the configured maximum length.
   # Inherits from +ArgumentError+ for backward compatibility with existing
   # +rescue ArgumentError+ clauses.
   class PasswordTooLong < ArgumentError; end
 
-  # Allows you to test the strength of multiple passwords without reading and
-  # parsing the dictionary data from disk each test. Dictionary data is read
-  # once from disk and stored in memory for the life of the Tester object.
+  # Evaluates password strength against dictionary lists, keyboard patterns,
+  # dates, sequences, and repeats. Construct via {Zxcvbn.tester}:
   #
-  # Example:
-  #
-  #   tester = Zxcvbn::Tester.new
-  #
-  #   tester.add_word_lists("custom" => ["words"])
+  #   tester = Zxcvbn.tester
+  #     .add_word_list('company', %w[acme corp])
+  #     .build
   #
   #   tester.test("password 1")
   #   tester.test("password 2")
-  #   tester.test("password 3")
   class Tester
-    # Default maximum password length when no +max_password_length:+ is given
-    # to {#initialize}. Passwords longer than this raise {PasswordTooLong}.
-    # Defaults to 256; override process-wide by setting the
-    # +ZXCVBN_MAX_PASSWORD_LENGTH+ environment variable before the gem loads,
-    # or per-instance via <tt>Tester.new(max_password_length: n)</tt>.
-    MAX_PASSWORD_LENGTH = begin
-      Integer(ENV.fetch('ZXCVBN_MAX_PASSWORD_LENGTH', 256))
-    rescue ArgumentError, TypeError
-      raise ArgumentError,
-            'ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; ' \
-            "got #{ENV['ZXCVBN_MAX_PASSWORD_LENGTH'].inspect}"
-    end
-
-    unless MAX_PASSWORD_LENGTH.positive?
-      raise ArgumentError,
-            "ZXCVBN_MAX_PASSWORD_LENGTH must be positive; got #{MAX_PASSWORD_LENGTH}"
-    end
-
+    # @param data [Data] pre-configured data
     # @param max_password_length [Integer] passwords longer than this raise
-    #   {PasswordTooLong} from {#test}. Defaults to {MAX_PASSWORD_LENGTH}.
-    def initialize(max_password_length: MAX_PASSWORD_LENGTH)
+    #   {PasswordTooLong} from {#test}
+    # @raise [ArgumentError] if max_password_length is not a positive integer
+    def initialize(data:, max_password_length:)
       unless max_password_length.is_a?(Integer) && max_password_length.positive?
         raise ArgumentError,
               "max_password_length must be a positive integer; got #{max_password_length.inspect}"
       end
 
-      @data = Data.new
+      @data = data
       @max_password_length = max_password_length
       @omnimatch = Omnimatch.new(@data)
     end
 
+    attr_reader :max_password_length
+
     # Evaluates a password and returns a {Score}.
     #
     # Raises {PasswordTooLong} if the password exceeds the +max_password_length+
-    # passed to {#initialize} (default: {MAX_PASSWORD_LENGTH}). The limit exists
-    # because scoring time grows super-quadratically on adversarial inputs such
-    # as short repeated sequences (e.g. <tt>"ab" * 500</tt>).
+    # passed to {#initialize}. The limit exists because scoring time grows
+    # super-quadratically on adversarial inputs such as short repeated sequences
+    # (e.g. <tt>"ab" * 500</tt>).
     #
     # @param password [String] the password to evaluate
     # @param user_inputs [Array<String>] caller-supplied words to treat as known
     # @return [Score]
     # @raise [PasswordTooLong] if the password exceeds the maximum length
     def test(password, user_inputs = [])
-      if password && password.length > @max_password_length
-        raise PasswordTooLong,
-              "Password exceeds the maximum length of #{@max_password_length}."
-      end
       password ||= ''
+      if password.length > @max_password_length
+        raise PasswordTooLong, "Password exceeds the maximum length of #{@max_password_length}."
+      end
+
       result = nil
       calc_time = Clock.realtime do
         reference_year = Time.now.year
         scorer = Scorer.new(@data, @omnimatch, reference_year)
-        matches = @omnimatch.matches(password, sanitize(user_inputs), reference_year:)
+        matches = @omnimatch.matches(password, user_inputs, reference_year:)
         result = scorer.most_guessable_match_sequence(password, matches)
       end
       result.with(
@@ -87,24 +68,9 @@ module Zxcvbn
       )
     end
 
-    # Adds custom word lists to the loaded data for all future {#test} calls.
-    #
-    # @param lists [Hash{String => Array<String>}] named word lists
-    # @return [void]
-    def add_word_lists(lists)
-      lists.each_pair { |name, words| @data.add_word_list(name, sanitize(words)) }
-      @omnimatch = Omnimatch.new(@data)
-    end
-
     # @return [String] a concise representation that omits the large dictionary data
     def inspect
       "#<#{self.class}:0x#{__id__.to_s(16)}>"
-    end
-
-    private
-
-    def sanitize(user_inputs)
-      user_inputs.select { |i| i.respond_to?(:downcase) }
     end
   end
 end

--- a/lib/zxcvbn/tester_builder.rb
+++ b/lib/zxcvbn/tester_builder.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'zxcvbn/data'
+require 'zxcvbn/tester'
+
+module Zxcvbn
+  # Fluent builder for constructing a {Tester} with custom word lists and options.
+  #
+  # Obtain a builder via {Zxcvbn.tester} and call {#build} to get the {Tester}.
+  #
+  # Example:
+  #
+  #   tester = Zxcvbn.tester
+  #     .add_word_list('company', %w[acme corp])
+  #     .max_password_length(75)
+  #     .build
+  class TesterBuilder
+    # Default maximum password length used when neither {#max_password_length} nor
+    # the +ZXCVBN_MAX_PASSWORD_LENGTH+ environment variable is set.
+    DEFAULT_MAX_PASSWORD_LENGTH = 256
+
+    def initialize
+      @word_lists = {}
+      @max_password_length = nil
+    end
+
+    # @param name [String] identifier for the word list; calling with the same name twice replaces the earlier list
+    # @param words [Array<String>] words to add
+    # @return [self]
+    def add_word_list(name, words)
+      @word_lists[name] = words
+      self
+    end
+
+    # @param length [Integer] maximum password length for the built {Tester}
+    # @return [self]
+    def max_password_length(length)
+      @max_password_length = length
+      self
+    end
+
+    # @return [Tester]
+    # @raise [ArgumentError] if max_password_length or ZXCVBN_MAX_PASSWORD_LENGTH is not a positive integer
+    def build
+      data = Data.new
+      @word_lists.each_pair { |name, words| data.add_word_list(name, words) }
+      Tester.new(data: data.freeze, max_password_length: effective_max_password_length).freeze
+    end
+
+    private
+
+    def effective_max_password_length
+      return @max_password_length if @max_password_length
+
+      value = begin
+        Integer(ENV.fetch('ZXCVBN_MAX_PASSWORD_LENGTH', DEFAULT_MAX_PASSWORD_LENGTH))
+      rescue ArgumentError, TypeError
+        raise ArgumentError,
+              'ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; ' \
+              "got #{ENV['ZXCVBN_MAX_PASSWORD_LENGTH'].inspect}"
+      end
+
+      unless value.positive?
+        raise ArgumentError,
+              'ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; ' \
+              "got #{ENV['ZXCVBN_MAX_PASSWORD_LENGTH'].inspect}"
+      end
+
+      value
+    end
+  end
+end

--- a/sig/zxcvbn.rbs
+++ b/sig/zxcvbn.rbs
@@ -4,10 +4,9 @@ module Zxcvbn
 
   VERSION: String
 
-  DATA_PATH: Pathname
-
-  type word_list = Hash[String, Array[String]]
   type user_inputs = Array[String]
 
-  def self.test: (String? password, ?user_inputs user_inputs, ?word_list word_lists) -> Score
+  def self.test: (String? password, ?user_inputs user_inputs) -> Score
+
+  def self.tester: () -> TesterBuilder
 end

--- a/sig/zxcvbn/data.rbs
+++ b/sig/zxcvbn/data.rbs
@@ -11,8 +11,6 @@ module Zxcvbn
       def initialize: (ranked: Hash[String, ranked_dictionary], tries: Hash[String, Trie]) -> void
     end
 
-    WRITE_MUTEX: Mutex
-
     @dictionaries: Dictionaries
     @adjacency_graphs: Hash[String, adjacency_graph]
     @graph_stats: graph_stats

--- a/sig/zxcvbn/tester.rbs
+++ b/sig/zxcvbn/tester.rbs
@@ -1,20 +1,15 @@
 module Zxcvbn
   class Tester
-    MAX_PASSWORD_LENGTH: Integer
-
     @data: Data
     @omnimatch: Omnimatch
+    @max_password_length: Integer
 
-    def initialize: (?max_password_length: Integer) -> void
+    def initialize: (data: Data, max_password_length: Integer) -> void
+
+    attr_reader max_password_length: Integer
 
     def test: (String? password, ?Array[untyped] user_inputs) -> Score
 
-    def add_word_lists: (Hash[String, Array[untyped]] lists) -> void
-
     def inspect: () -> String
-
-    private
-
-    def sanitize: (Array[untyped] user_inputs) -> Array[String]
   end
 end

--- a/sig/zxcvbn/tester_builder.rbs
+++ b/sig/zxcvbn/tester_builder.rbs
@@ -1,0 +1,16 @@
+module Zxcvbn
+  class TesterBuilder
+    DEFAULT_MAX_PASSWORD_LENGTH: Integer
+
+    @word_lists: Hash[String, Array[untyped]]
+    @max_password_length: Integer?
+
+    def initialize: () -> void
+
+    def add_word_list: (String name, Array[untyped] words) -> TesterBuilder
+
+    def max_password_length: (Integer length) -> TesterBuilder
+
+    def build: () -> Tester
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'zxcvbn'
 Dir[Pathname.new(File.expand_path(__dir__)).join('support/**/*.rb')].each { |f| require f }
 
 ZXCVBN_TEST_DATA = Zxcvbn::Data.new.freeze
+ZXCVBN_TESTER = Zxcvbn::Tester.new(data: ZXCVBN_TEST_DATA, max_password_length: Zxcvbn::TesterBuilder::DEFAULT_MAX_PASSWORD_LENGTH).freeze
 
 RSpec.configure do |config|
   config.include JsHelpers

--- a/spec/zxcvbn/feedback_giver_spec.rb
+++ b/spec/zxcvbn/feedback_giver_spec.rb
@@ -3,9 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Zxcvbn::FeedbackGiver do
-  # NOTE: We go in via the tester because the `FeedbackGiver` relies on both
-  #       Omnimatch and the Scorer, which are troublesome to wire up for tests
-  let(:tester) { Zxcvbn::Tester.new }
+  let(:tester) { ZXCVBN_TESTER }
 
   describe '.get_feedback' do
     it "gives empty feedback when a password's score is good" do

--- a/spec/zxcvbn/tester_builder_spec.rb
+++ b/spec/zxcvbn/tester_builder_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Zxcvbn::TesterBuilder do
+  describe 'Zxcvbn.tester' do
+    it 'returns a Builder' do
+      expect(Zxcvbn.tester).to be_a(Zxcvbn::TesterBuilder)
+    end
+
+    it 'returns a new Builder on each call' do
+      expect(Zxcvbn.tester).not_to be(Zxcvbn.tester)
+    end
+  end
+
+  describe '#build' do
+    it 'returns a Tester' do
+      expect(Zxcvbn.tester.build).to be_a(Zxcvbn::Tester)
+    end
+
+    it 'returns a frozen Tester' do
+      expect(Zxcvbn.tester.build).to be_frozen
+    end
+
+    it 'uses the default max_password_length when none is set' do
+      expect(Zxcvbn.tester.build.max_password_length).to eq Zxcvbn::TesterBuilder::DEFAULT_MAX_PASSWORD_LENGTH
+    end
+
+    it 'raises ArgumentError when ZXCVBN_MAX_PASSWORD_LENGTH is not an integer' do
+      stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => 'abc' })
+      expect { Zxcvbn.tester.build }.to raise_error(ArgumentError)
+    end
+
+    it 'raises ArgumentError when ZXCVBN_MAX_PASSWORD_LENGTH is non-positive' do
+      stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '0' })
+      expect { Zxcvbn.tester.build }.to raise_error(ArgumentError)
+    end
+
+    it 'reads max_password_length from ZXCVBN_MAX_PASSWORD_LENGTH when none is set' do
+      stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '50' })
+      expect(Zxcvbn.tester.build.max_password_length).to eq 50
+    end
+
+    it 'ignores ZXCVBN_MAX_PASSWORD_LENGTH when an explicit value is set' do
+      stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '50' })
+      expect(Zxcvbn.tester.max_password_length(10).build.max_password_length).to eq 10
+    end
+
+    it 'honours a custom max_password_length' do
+      tester = Zxcvbn.tester.max_password_length(10).build
+      expect { tester.test('a' * 10) }.not_to raise_error
+      expect { tester.test('a' * 11) }.to raise_error(Zxcvbn::PasswordTooLong)
+    end
+
+    it 'applies an added word list' do
+      tester = Zxcvbn.tester.add_word_list('envato', ['envato']).build
+      expect(tester.test('envato').score).to eq 0
+    end
+
+    it 'returns independent testers on each build' do
+      builder = Zxcvbn.tester
+      expect(builder.build).not_to be(builder.build)
+    end
+
+    it 'raises ArgumentError for non-positive max_password_length' do
+      expect { Zxcvbn.tester.max_password_length(0).build }.to raise_error(ArgumentError)
+    end
+
+    it 'accumulates multiple add_word_list calls' do
+      tester = Zxcvbn.tester
+                     .add_word_list('a', ['foo'])
+                     .add_word_list('b', ['bar'])
+                     .build
+      expect(tester.test('foo').score).to eq 0
+      expect(tester.test('bar').score).to eq 0
+    end
+  end
+
+  describe 'method chaining' do
+    it 'add_word_list returns self' do
+      builder = Zxcvbn.tester
+      expect(builder.add_word_list('x', [])).to be(builder)
+    end
+
+    it 'max_password_length returns self' do
+      builder = Zxcvbn.tester
+      expect(builder.max_password_length(10)).to be(builder)
+    end
+  end
+end

--- a/spec/zxcvbn/tester_spec.rb
+++ b/spec/zxcvbn/tester_spec.rb
@@ -4,12 +4,9 @@ require 'spec_helper'
 require 'benchmark'
 
 RSpec.describe Zxcvbn::Tester do
-  let(:tester) { Zxcvbn::Tester.new }
+  let(:tester) { ZXCVBN_TESTER }
 
   context 'JS compatibility' do
-    before(:context) { @shared_tester = Zxcvbn::Tester.new }
-    let(:tester) { @shared_tester }
-
     TEST_PASSWORDS.each do |password|
       it "matches the JS result for #{password}" do
         ruby_result = tester.test(password)
@@ -91,7 +88,7 @@ RSpec.describe Zxcvbn::Tester do
   end
 
   context 'with a custom global dictionary' do
-    before { tester.add_word_lists('envato' => ['envato']) }
+    let(:tester) { Zxcvbn.tester.add_word_list('envato', ['envato']).build }
 
     it 'scores them against the dictionary' do
       result = tester.test('envato')
@@ -99,19 +96,11 @@ RSpec.describe Zxcvbn::Tester do
     end
 
     context 'with invalid entries in a custom dictionary' do
-      before { tester.add_word_lists('themeforest' => [nil, 1, 'themeforest']) }
+      let(:tester) { Zxcvbn.tester.add_word_list('themeforest', [nil, 1, 'themeforest']).build }
 
       it 'ignores those entries' do
         expect(tester.test('themeforest')).to have_attributes(score: 0)
       end
-    end
-  end
-
-  context 'when word lists are added after a prior test call' do
-    it 'picks up the new word list in subsequent test calls' do
-      expect(tester.test('envato').score).to be > 0
-      tester.add_word_lists('envato' => ['envato'])
-      expect(tester.test('envato').score).to eq 0
     end
   end
 
@@ -129,17 +118,17 @@ RSpec.describe Zxcvbn::Tester do
 
   context 'with a very long password' do
     it 'accepts passwords at the length limit' do
-      at_limit = 'a' * Zxcvbn::Tester::MAX_PASSWORD_LENGTH
+      at_limit = 'a' * tester.max_password_length
       expect { tester.test(at_limit) }.not_to raise_error
     end
 
     it 'raises PasswordTooLong for passwords over the length limit' do
-      over_limit = 'a' * (Zxcvbn::Tester::MAX_PASSWORD_LENGTH + 1)
+      over_limit = 'a' * (tester.max_password_length + 1)
       expect { tester.test(over_limit) }.to raise_error(Zxcvbn::PasswordTooLong, /exceeds the maximum length of/)
     end
 
     it 'completes in reasonable time for adversarial repeat inputs at the limit' do
-      adversarial = 'ab' * (Zxcvbn::Tester::MAX_PASSWORD_LENGTH / 2)
+      adversarial = 'ab' * (tester.max_password_length / 2)
       elapsed = Benchmark.realtime { tester.test(adversarial) }
       expect(elapsed).to be < 5
     end
@@ -149,7 +138,7 @@ RSpec.describe Zxcvbn::Tester do
       # Use a high-entropy string so the whole password is a single bruteforce
       # match: length 400 → 10**400 → Float::MAX → crack time overflows to Infinity
       # without the clamp.
-      high_limit_tester = Zxcvbn::Tester.new(max_password_length: 400)
+      high_limit_tester = Zxcvbn.tester.max_password_length(400).build
       saved = srand(7)
       high_entropy = (1..400).map { rand(33..126).chr }.join
       srand(saved)
@@ -158,8 +147,20 @@ RSpec.describe Zxcvbn::Tester do
     end
   end
 
+  it 'raises ArgumentError for non-positive max_password_length' do
+    expect do
+      Zxcvbn::Tester.new(data: ZXCVBN_TEST_DATA, max_password_length: 0)
+    end.to raise_error(ArgumentError)
+  end
+
+  it 'raises ArgumentError for non-integer max_password_length' do
+    expect do
+      Zxcvbn::Tester.new(data: ZXCVBN_TEST_DATA, max_password_length: 'ten')
+    end.to raise_error(ArgumentError)
+  end
+
   context 'with a custom max_password_length' do
-    let(:tester) { Zxcvbn::Tester.new(max_password_length: 10) }
+    let(:tester) { Zxcvbn.tester.max_password_length(10).build }
 
     it 'accepts passwords at the custom limit' do
       expect { tester.test('a' * 10) }.not_to raise_error
@@ -167,10 +168,6 @@ RSpec.describe Zxcvbn::Tester do
 
     it 'raises PasswordTooLong for passwords over the custom limit' do
       expect { tester.test('a' * 11) }.to raise_error(Zxcvbn::PasswordTooLong)
-    end
-
-    it 'raises ArgumentError for non-positive max_password_length' do
-      expect { Zxcvbn::Tester.new(max_password_length: 0) }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/zxcvbn_spec.rb
+++ b/spec/zxcvbn_spec.rb
@@ -17,22 +17,11 @@ RSpec.describe 'Zxcvbn.test' do
     end
   end
 
-  context 'with a password, user input and custom word lists' do
-    it 'returns a result' do
-      result = Zxcvbn.test('password', ['inputs'], { 'list' => ['words'] })
-      expect(result.guesses).to_not be_nil
-    end
-  end
-
   context 'with a password over the length limit' do
-    let(:over_limit) { 'a' * (Zxcvbn::Tester::MAX_PASSWORD_LENGTH + 1) }
+    let(:over_limit) { 'a' * (Zxcvbn::TesterBuilder::DEFAULT_MAX_PASSWORD_LENGTH + 1) }
 
-    it 'raises PasswordTooLong via the shared default tester' do
+    it 'raises PasswordTooLong' do
       expect { Zxcvbn.test(over_limit) }.to raise_error(Zxcvbn::PasswordTooLong)
-    end
-
-    it 'raises PasswordTooLong via a fresh tester when word_lists are supplied' do
-      expect { Zxcvbn.test(over_limit, [], { 'custom' => ['word'] }) }.to raise_error(Zxcvbn::PasswordTooLong)
     end
   end
 end


### PR DESCRIPTION
## Context

`Tester` construction is ad-hoc: `Tester.new` has no-arg defaults, custom word lists require calling `add_word_lists` after construction, and `ZXCVBN_MAX_PASSWORD_LENGTH` is read at gem load time. This makes the construction path hard to reason about and awkward to extend.

## Changes

- Adds `Zxcvbn::TesterBuilder` with a fluent API: `Zxcvbn.tester.add_word_list(name, words).max_password_length(n).build`
- `Zxcvbn.tester` returns a new builder; the shared tester backing `Zxcvbn.test` is built lazily through the same path
- `Data` construction, word list population, and `max_password_length` validation (including `ZXCVBN_MAX_PASSWORD_LENGTH`) are now the builder's responsibility — deferred to `build` time, not gem load time
- `Tester`, `Data`, and `Omnimatch` are frozen after construction
- `Tester::MAX_PASSWORD_LENGTH`, `Tester#add_word_lists`, and the `word_lists:` argument to `Zxcvbn.test` are removed
- `Tester.new` now requires explicit `data:` and `max_password_length:` — use `Zxcvbn.tester.build` instead
- README, CHANGELOG, YARD docs, and RBS signatures updated throughout

## Consequences

- `Tester`, `Data`, and `Omnimatch` are immutable after construction — callers can no longer mutate them after `build`
- Breaking changes for callers using `Tester.new`, `Tester#add_word_lists`, or the `word_lists:` argument to `Zxcvbn.test` — all covered in the migration guide
- `ZXCVBN_MAX_PASSWORD_LENGTH` is now read at build time; for `Zxcvbn.test` this is the first call, so it can no longer be treated as a load-time constant