### PR TITLE
Cache dictionary matchers in Omnimatch to avoid rebuilding per test call

### DIFF
--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -22,6 +22,10 @@ module Zxcvbn
     # @param data [Data] loaded frequency lists and adjacency graphs
     def initialize(data)
       @data = data
+      dicts = data.dictionaries
+      @dictionary_matchers = dicts.ranked.map do |name, dictionary|
+        Matchers::Dictionary.new(name, dictionary, dicts.tries[name])
+      end
       @matchers = build_matchers
     end
 
@@ -74,23 +78,18 @@ module Zxcvbn
     def reverse_dictionary_matches(password, user_inputs = [])
       reversed = password.reverse
       n = password.length
-      matches = []
 
-      dicts = @data.dictionaries
-      matchers = dicts.ranked.map do |name, dictionary|
-        trie = dicts.tries[name]
-        Matchers::Dictionary.new(name, dictionary, trie)
-      end
-
+      matchers = @dictionary_matchers
       if user_inputs.any?
         user_ranked_dictionary = DictionaryRanker.rank_dictionary(user_inputs)
-        matchers << Matchers::Dictionary.new(
+        matchers += [Matchers::Dictionary.new(
           'user_inputs',
           user_ranked_dictionary,
           Trie.from_ranked(user_ranked_dictionary)
-        )
+        )]
       end
 
+      matches = []
       matchers.each do |matcher|
         matcher.matches(reversed).each do |match|
           match.token    = match.token.reverse
@@ -106,15 +105,8 @@ module Zxcvbn
     end
 
     def build_matchers
-      matchers = []
-      dicts = @data.dictionaries
-      dictionary_matchers = dicts.ranked.map do |name, dictionary|
-        trie = dicts.tries[name]
-        Matchers::Dictionary.new(name, dictionary, trie)
-      end
-      l33t_matcher = Matchers::L33t.new(dictionary_matchers)
-      matchers += dictionary_matchers
-      matchers += [
+      l33t_matcher = Matchers::L33t.new(@dictionary_matchers)
+      @dictionary_matchers + [
         l33t_matcher,
         Matchers::Spatial.new(@data.adjacency_graphs),
         Matchers::Digits.new,
@@ -123,7 +115,6 @@ module Zxcvbn
         Matchers::Year.new,
         Matchers::Date.new
       ]
-      matchers
     end
   end
 end

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -20,8 +20,8 @@ module Zxcvbn
       h[n] = n < 2 ? 1.0 : h[n - 1] * n
     end.freeze
 
-    # Hash{Integer => Float} — powers of {MIN_GUESSES_BEFORE_GROWING_SEQUENCE} for the
-    # additive sequence-length penalty. Keys must be non-negative integers.
+    # Hash{Integer => Float} — powers of {MIN_GUESSES_BEFORE_GROWING_SEQUENCE} for
+    # the additive sequence-length penalty. Keys must be non-negative integers.
     # Precomputed to 77 (the last value before overflow); returns Float::MAX for
     # any key > 77.
     MIN_GUESSES_POW = (0..77).each_with_object(Hash.new { Float::MAX }) do |n, h|

--- a/sig/zxcvbn/omnimatch.rbs
+++ b/sig/zxcvbn/omnimatch.rbs
@@ -1,6 +1,7 @@
 module Zxcvbn
   class Omnimatch
     @data: Data
+    @dictionary_matchers: Array[Matchers::Dictionary]
     @matchers: Array[untyped]
 
     def initialize: (Data data) -> void


### PR DESCRIPTION
## Context

`Omnimatch#reverse_dictionary_matches` rebuilds all `Matchers::Dictionary` instances on every `Tester#test` call by re-reading `@data.dictionaries` each time. The forward matchers are already snapshotted once in `Omnimatch#initialize` via `build_matchers`, so the two phases operate from different construction points — a latent inconsistency exposed if `Tester.new` is called directly with unfrozen `Data`.

## Changes

- Builds `@dictionary_matchers` once in `Omnimatch#initialize`, shared by both `build_matchers` (forward path) and `reverse_dictionary_matches` (reverse path)
- Forward and reverse matching now use the same snapshot of the data
- Adds `@dictionary_matchers: Array[Matchers::Dictionary]` to `sig/zxcvbn/omnimatch.rbs`
- Minor comment reflow in `scorer.rb`

## Consequences

- Forward and reverse dictionary matchers are now guaranteed to see the same data snapshot
- Six `Matchers::Dictionary` objects are no longer allocated on every `test` call