### PR TITLE
Deeply freeze the Tester object graph for safe concurrent sharing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,7 @@
 Metrics/AbcSize:
   Exclude:
     - 'lib/zxcvbn/crack_time.rb'
+    - 'lib/zxcvbn/data.rb'
     - 'lib/zxcvbn/feedback_giver.rb'
     - 'lib/zxcvbn/guesses.rb'
     - 'lib/zxcvbn/matchers/date.rb'

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -31,10 +31,14 @@ module Zxcvbn
         'passwords' => read_word_list('passwords.txt'),
         'surnames' => read_word_list('surnames.txt'),
         'us_tv_and_film' => read_word_list('us_tv_and_film.txt')
-      )
-      @dictionaries = Dictionaries.new(ranked:, tries: build_tries(ranked))
-      @adjacency_graphs = JSON.parse(DATA_PATH.join('adjacency_graphs.json').read)
-      @graph_stats = compute_graph_stats
+      ).tap { |r| r.each_value(&:freeze) }.freeze
+      tries = build_tries(ranked).tap { |t| t.each_value(&:freeze) }.freeze
+      @dictionaries = Dictionaries.new(ranked:, tries:)
+      @adjacency_graphs =
+        JSON.parse(DATA_PATH.join('adjacency_graphs.json').read)
+            .tap { |gs| gs.each_value { |g| g.each_value { |a| a.each(&:freeze).freeze }.freeze } }
+            .freeze
+      @graph_stats = compute_graph_stats.each_value(&:freeze).freeze
     end
 
     attr_reader :adjacency_graphs, :graph_stats, :dictionaries
@@ -51,11 +55,11 @@ module Zxcvbn
     # @param list [Array<String>] ordered words (most common first)
     # @return [void]
     def add_word_list(name, list)
-      ranked_dict = DictionaryRanker.rank_dictionary(list.select { |w| w.respond_to?(:downcase) })
-      trie = Trie.from_ranked(ranked_dict)
+      ranked_dict = DictionaryRanker.rank_dictionary(list.select { |w| w.respond_to?(:downcase) }).freeze
+      trie = Trie.from_ranked(ranked_dict).freeze
       @dictionaries = @dictionaries.with(
-        ranked: @dictionaries.ranked.merge(name => ranked_dict),
-        tries: @dictionaries.tries.merge(name => trie)
+        ranked: @dictionaries.ranked.merge(name => ranked_dict).freeze,
+        tries: @dictionaries.tries.merge(name => trie).freeze
       )
     end
 

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -24,9 +24,9 @@ module Zxcvbn
       @data = data
       dicts = data.dictionaries
       @dictionary_matchers = dicts.ranked.map do |name, dictionary|
-        Matchers::Dictionary.new(name, dictionary, dicts.tries[name])
-      end
-      @matchers = build_matchers
+        Matchers::Dictionary.new(name, dictionary, dicts.tries[name]).freeze
+      end.freeze
+      @matchers = build_matchers.each(&:freeze).freeze
     end
 
     # Returns all matches found in the password across every registered matcher.
@@ -105,9 +105,8 @@ module Zxcvbn
     end
 
     def build_matchers
-      l33t_matcher = Matchers::L33t.new(@dictionary_matchers)
       @dictionary_matchers + [
-        l33t_matcher,
+        Matchers::L33t.new(@dictionary_matchers),
         Matchers::Spatial.new(@data.adjacency_graphs),
         Matchers::Digits.new,
         Matchers::Repeat.new,

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -33,7 +33,7 @@ module Zxcvbn
 
       @data = data
       @max_password_length = max_password_length
-      @omnimatch = Omnimatch.new(@data)
+      @omnimatch = Omnimatch.new(@data).freeze
     end
 
     attr_reader :max_password_length

--- a/lib/zxcvbn/trie.rb
+++ b/lib/zxcvbn/trie.rb
@@ -50,5 +50,17 @@ module Zxcvbn
 
       results
     end
+
+    def freeze
+      freeze_node(@root)
+      super
+    end
+
+    private
+
+    def freeze_node(node)
+      node.each_value { |v| freeze_node(v) if v.is_a?(Hash) }
+      node.freeze
+    end
   end
 end

--- a/sig/zxcvbn/trie.rbs
+++ b/sig/zxcvbn/trie.rbs
@@ -10,6 +10,8 @@ module Zxcvbn
 
     def insert: (String word, Integer rank) -> void
 
+    def freeze: () -> self
+
     def search_prefixes: (String text, Integer start_pos) -> Array[[String, Integer?, Integer, Integer]]
   end
 end


### PR DESCRIPTION
## Context

`Tester` is designed to be constructed once and shared across threads. `TesterBuilder#build` freezes the `Tester` and `Data` instances, but the freeze is shallow — `Omnimatch`, its matchers, the adjacency graphs, ranked dictionaries, and tries are all left mutable.

## Changes

- `Tester#initialize` freezes the `Omnimatch` instance after construction
- `Omnimatch#initialize` freezes `@dictionary_matchers` and `@matchers` (and each element) at creation; adds a `freeze` override to delegate to those arrays
- `Omnimatch#build_matchers` inlines the `L33t` matcher like the others, removing the intermediate variable
- `Data#initialize` deeply freezes `@adjacency_graphs` (including nested hashes and their string arrays), `@graph_stats`, ranked dictionaries, and tries
- `Data#add_word_list` applies the same freezing so custom word lists are consistent with built-in ones
- `Trie#freeze` recursively freezes `@root` and all descendant nodes

## Consequences

The full object graph reachable from a constructed `Tester` is now frozen. Any attempt to mutate shared data after construction raises `FrozenError`, making concurrent use safer and bugs from accidental mutation detectable immediately.