### PR TITLE
Tighten JS compatibility tests and fix test helper float handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zxcvbn-ruby
 
-This is a Ruby port of Dropbox's [zxcvbn.js][zxcvbn.js] JavaScript library.
+This is a Ruby port of Dropbox's [zxcvbn.js][zxcvbn.js] JavaScript library, targeting **zxcvbn.js v4** and aiming to produce identical results.
 
 ## Development status [![CI Status](https://github.com/envato/zxcvbn-ruby/workflows/CI/badge.svg)](https://github.com/envato/zxcvbn-ruby/actions?query=workflow%3ACI)
 

--- a/spec/support/js_helpers.rb
+++ b/spec/support/js_helpers.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'mini_racer'
-require 'json'
 
 module JsHelpers
   class JsMethodInvoker
@@ -16,9 +15,8 @@ module JsHelpers
       @ctx.eval(string)
     end
 
-    def eval_convert_object(string)
-      serialized = js_eval("JSON.stringify(#{string})")
-      JSON.parse(serialized)
+    def eval_convert_object(javascript)
+      js_eval(javascript)
     end
   end
 

--- a/spec/zxcvbn/tester_spec.rb
+++ b/spec/zxcvbn/tester_spec.rb
@@ -15,9 +15,12 @@ RSpec.describe Zxcvbn::Tester do
         expect(ruby_result.calc_time).not_to be_nil
         expect(ruby_result.password).to eq js_result['password']
         expect(ruby_result.score).to eq js_result['score']
-        expect(ruby_result.sequence.count).to eq js_result['sequence'].count
+        # Absorbs final-ULP log10 differences between Ruby and JS math library implementations.
+        expect(ruby_result.guesses_log10).to be_within(1e-13).of(js_result['guesses_log10'])
+        expect(ruby_result.crack_times_seconds).to eq js_result['crack_times_seconds']
+        expect(ruby_result.crack_times_display).to eq js_result['crack_times_display']
 
-        expect(ruby_result.guesses_log10).to be_within(0.01).of(js_result['guesses_log10'])
+        expect(ruby_result.sequence.count).to eq js_result['sequence'].count
 
         ruby_result.sequence.zip(js_result['sequence']).each_with_index do |(ruby_match, js_match), idx|
           # Ruby uses 'year' where JS v4 uses 'regex' (regex_name: 'recent_year') — intentional naming difference.
@@ -25,6 +28,11 @@ RSpec.describe Zxcvbn::Tester do
           expect(ruby_pattern).to eq(js_match['pattern']), "match #{idx} pattern mismatch"
           expect(ruby_match.i).to eq(js_match['i']), "match #{idx} i mismatch"
           expect(ruby_match.j).to eq(js_match['j']), "match #{idx} j mismatch"
+          expect(ruby_match.token).to eq(js_match['token']), "match #{idx} token mismatch"
+          expect(ruby_match.guesses_log10).to(
+            be_within(1e-13).of(js_match['guesses_log10']),
+            "match #{idx} guesses_log10 mismatch"
+          )
         end
 
         expect(ruby_result.feedback.warning).to eq js_result['feedback']['warning']


### PR DESCRIPTION
## Context

The JS compatibility tests compare Ruby results against zxcvbn.js v4 for a set of test passwords. The test helper fetches JS results by calling `JSON.stringify` in JS and `JSON.parse` in Ruby. The compatibility assertions check `score`, `sequence` shape, and `guesses_log10` within a loose `be_within(0.01)` tolerance. Fields such as `crack_times_seconds`, `crack_times_display`, and per-match `token` and `guesses_log10` are not verified. The README does not state which version of zxcvbn.js the gem targets or that it aims for identical results.

## Changes

- Replace the `JSON.stringify` + `JSON.parse` round-trip in the test helper with MiniRacer's native object conversion (`ctx.eval` returns JS Numbers as Ruby Floats directly).
- Tighten `guesses_log10` tolerance from `be_within(0.01)` to `be_within(1e-13)` (the remaining difference is a final-ULP artefact of Ruby vs JS `Math.log10` implementations, not an algorithmic divergence).
- Add assertions for `crack_times_seconds`, `crack_times_display`, and per-match `token` and `guesses_log10`.
- State in the README that the gem targets zxcvbn.js v4 and aims to produce identical results.

## Consequences

The JS compatibility tests now verify the full result surface — numeric accuracy, crack time values and display strings, and per-match tokens — rather than just score and a loose guess-count check. The float type mismatch that caused `crack_times_seconds` comparisons to fail (whole-number doubles serialised as JSON integers) is eliminated at the source rather than worked around in the assertions.