### PR TITLE
Fix RBS runtime type checker failures

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ begin
 
     desc 'Run RBS runtime type checker with RSpec'
     task :test do
-      sh "rbs -I sig test --target 'Zxcvbn::*' rspec"
+      sh "rbs -I sig test --target 'Zxcvbn::*' rspec --tag '~no_rbs'"
     end
 
     desc 'List RBS types'

--- a/sig/zxcvbn/data.rbs
+++ b/sig/zxcvbn/data.rbs
@@ -25,7 +25,7 @@ module Zxcvbn
 
     def initialize: () -> void
 
-    def add_word_list: (String name, Array[String] list) -> void
+    def add_word_list: (String name, Array[untyped] list) -> void
 
     private
 

--- a/sig/zxcvbn/omnimatch.rbs
+++ b/sig/zxcvbn/omnimatch.rbs
@@ -6,13 +6,13 @@ module Zxcvbn
 
     def initialize: (Data data) -> void
 
-    def matches: (String password, ?Array[String] user_inputs, ?reference_year: Integer) -> Array[MatchBuilder]
+    def matches: (String password, ?Array[untyped] user_inputs, ?reference_year: Integer) -> Array[MatchBuilder]
 
     private
 
-    def user_input_matchers: (Array[String] user_inputs) -> Array[untyped]
+    def user_input_matchers: (Array[untyped] user_inputs) -> Array[untyped]
 
-    def reverse_dictionary_matches: (String password, ?Array[String] user_inputs) -> Array[MatchBuilder]
+    def reverse_dictionary_matches: (String password, ?Array[untyped] user_inputs) -> Array[MatchBuilder]
 
     def build_matchers: () -> Array[untyped]
   end

--- a/sig/zxcvbn/tester.rbs
+++ b/sig/zxcvbn/tester.rbs
@@ -4,7 +4,7 @@ module Zxcvbn
     @omnimatch: Omnimatch
     @max_password_length: Integer
 
-    def initialize: (data: Data, max_password_length: Integer) -> void
+    def initialize: (data: Data, max_password_length: untyped) -> void
 
     attr_reader max_password_length: Integer
 

--- a/spec/zxcvbn/tester_spec.rb
+++ b/spec/zxcvbn/tester_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Zxcvbn::Tester do
       expect { tester.test(over_limit) }.to raise_error(Zxcvbn::PasswordTooLong, /exceeds the maximum length of/)
     end
 
-    it 'completes in reasonable time for adversarial repeat inputs at the limit' do
+    it 'completes in reasonable time for adversarial repeat inputs at the limit', :no_rbs do
       adversarial = 'ab' * (tester.max_password_length / 2)
       elapsed = Benchmark.realtime { tester.test(adversarial) }
       expect(elapsed).to be < 5


### PR DESCRIPTION
## Context

Several methods accept-then-validate their inputs at runtime: `Data#add_word_list` and `Omnimatch#matches` filter non-string entries with `respond_to?(:downcase)`/`select`, and `Tester#initialize` raises `ArgumentError` for non-integer `max_password_length`. The RBS signatures for these methods were typed more strictly than the implementations actually require, so the runtime type checker was intercepting calls before the validation logic could run.

The adversarial-input timing test (`'ab' * 128`) passes comfortably in normal runs but the RBS runtime checker wraps every method call, inflating its elapsed time from <1s to ~17s.

## Changes

- Relax `Array[String]` → `Array[untyped]` on `Data#add_word_list` and the `user_inputs` parameters of `Omnimatch#matches`, `#user_input_matchers`, and `#reverse_dictionary_matches`
- Relax `max_password_length: Integer` → `max_password_length: untyped` on `Tester#initialize`
- Tag the adversarial-input timing test `:no_rbs` and pass `--tag '~no_rbs'` to `rake rbs:test`

## Consequences

`rake rbs:test` goes from 4 failures to 0. The timing test still runs (and passes) under `rake spec`. The relaxed `untyped` signatures reflect the real contract: callers may pass anything, the methods validate and filter internally.