### PR TITLE
Complete the deeply-frozen guarantee for concurrent sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Audit any code that gates on `result.score` (e.g. form validation thresholds), p
 
  - [Steve Hodgkiss](https://github.com/stevehodgkiss)
  - [Matthieu Aussaguel](https://github.com/matthieua)
- - [_et al._](https://github.com/envato/zxcvbn-ruby/graphs/contributors)
+ - [_et al._](https://github.com/envato/zxcvbn-ruby/graphs/contributors?all=1)
 
 ## License [![license](https://img.shields.io/github/license/mashape/apistatus.svg?style=flat-square)](https://github.com/envato/zxcvbn-ruby/blob/HEAD/LICENSE.txt)
 

--- a/lib/zxcvbn/feedback.rb
+++ b/lib/zxcvbn/feedback.rb
@@ -11,7 +11,7 @@ module Zxcvbn
     # @param warning [String] warning message (default: empty string)
     # @param suggestions [Array<String>] improvement tips (default: [])
     def initialize(warning: nil, suggestions: [])
-      super(warning: warning || '', suggestions:)
+      super(warning: warning || '', suggestions: suggestions.freeze)
     end
   end
 end

--- a/lib/zxcvbn/feedback_giver.rb
+++ b/lib/zxcvbn/feedback_giver.rb
@@ -145,21 +145,13 @@ module Zxcvbn
       word = match.token
 
       if word =~ Zxcvbn::Guesses::START_UPPER
-        suggestions.push "Capitalization doesn't help very much"
+        suggestions.push("Capitalization doesn't help very much")
       elsif word =~ Zxcvbn::Guesses::ALL_UPPER && word.downcase != word
-        suggestions.push(
-          'All-uppercase is almost as easy to guess as all-lowercase'
-        )
+        suggestions.push('All-uppercase is almost as easy to guess as all-lowercase')
       end
 
       suggestions.push("Reversed words aren't much harder to guess") if match.reversed && match.token.length >= 4
-
-      if match.l33t
-        suggestions.push(
-          "Predictable substitutions like '@' instead of 'a' \
-don't help very much"
-        )
-      end
+      suggestions.push("Predictable substitutions like '@' instead of 'a' don't help very much") if match.l33t
 
       Feedback.new(warning:, suggestions:)
     end

--- a/lib/zxcvbn/match_builder.rb
+++ b/lib/zxcvbn/match_builder.rb
@@ -9,7 +9,7 @@ module Zxcvbn
   MatchBuilder = Struct.new(*Match.members, keyword_init: true) do
     # @return [Match] immutable match with the current attribute values
     def build
-      Match.new(**to_h)
+      Match.new(**to_h.tap { |h| h[:sub]&.freeze })
     end
   end
 end

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -161,9 +161,9 @@ module Zxcvbn
       Score.new(
         password:,
         guesses:,
-        sequence:,
-        crack_times_seconds: attack_times[:crack_times_seconds],
-        crack_times_display: attack_times[:crack_times_display],
+        sequence: sequence.freeze,
+        crack_times_seconds: attack_times[:crack_times_seconds].freeze,
+        crack_times_display: attack_times[:crack_times_display].freeze,
         score: guesses_to_score(guesses)
       )
     end

--- a/lib/zxcvbn/trie.rb
+++ b/lib/zxcvbn/trie.rb
@@ -52,15 +52,12 @@ module Zxcvbn
     end
 
     def freeze
-      freeze_node(@root)
+      stack = [@root]
+      while (node = stack.pop)
+        node.each_value { |v| stack.push(v) if v.is_a?(Hash) }
+        node.freeze
+      end
       super
-    end
-
-    private
-
-    def freeze_node(node)
-      node.each_value { |v| freeze_node(v) if v.is_a?(Hash) }
-      node.freeze
     end
   end
 end

--- a/spec/zxcvbn/thread_safety_spec.rb
+++ b/spec/zxcvbn/thread_safety_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Thread safety' do
+  let(:tester) { ZXCVBN_TESTER }
+
+  describe 'concurrent Zxcvbn.test from N threads' do
+    it 'returns consistent results' do
+      threads = Array.new(5) { Thread.new { Zxcvbn.test('password') } }
+      results = threads.map(&:value)
+
+      expect(results.map(&:guesses).uniq).to eq [results.first.guesses]
+      expect(results.map(&:score).uniq).to eq [results.first.score]
+    end
+  end
+
+  describe 'FrozenError on nested collections' do
+    let(:result) { tester.test('correcthorsebatterystaple') }
+
+    specify 'sequence is frozen' do
+      expect { result.sequence.push(nil) }.to raise_error(FrozenError)
+    end
+
+    specify 'crack_times_seconds is frozen' do
+      expect { result.crack_times_seconds['online_throttling_100_per_hour'] = 0 }.to raise_error(FrozenError)
+    end
+
+    specify 'crack_times_display is frozen' do
+      expect { result.crack_times_display['online_throttling_100_per_hour'] = 'evil' }.to raise_error(FrozenError)
+    end
+
+    specify 'feedback suggestions is frozen' do
+      expect { result.feedback.suggestions.push('evil') }.to raise_error(FrozenError)
+    end
+
+    specify 'DEFAULT_FEEDBACK suggestions is frozen' do
+      expect { Zxcvbn::FeedbackGiver::DEFAULT_FEEDBACK.suggestions.push('evil') }.to raise_error(FrozenError)
+    end
+
+    specify 'match sub hash is frozen' do
+      l33t_result = tester.test('p@ssword')
+      l33t_match = l33t_result.sequence.find(&:sub)
+      skip 'no l33t match found' unless l33t_match
+
+      expect { l33t_match.sub['@'] = 'EVIL' }.to raise_error(FrozenError)
+    end
+  end
+
+  describe 'concurrent default_tester initialization' do
+    around do |example|
+      saved = Zxcvbn.instance_variable_get(:@default_tester)
+      Zxcvbn.instance_variable_set(:@default_tester, nil)
+      example.run
+    ensure
+      Zxcvbn.instance_variable_set(:@default_tester, saved)
+    end
+
+    it 'initializes exactly one shared tester under concurrent pressure' do
+      testers = Array.new(5) { Thread.new { Zxcvbn.send(:default_tester) } }.map(&:value)
+      expect(testers.uniq.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
## Context

PR #106 freezes the `Tester` object graph and advertises safe concurrent sharing. The nested collections inside `Score` (`sequence`, `crack_times_seconds`, `crack_times_display`), the `sub` hash on `Match`, and the `suggestions` array on `Feedback` are not frozen, leaving the guarantee incomplete. `Trie#freeze` is implemented recursively, causing `SystemStackError` for words longer than ~5000 characters. No tests exist to assert any of these invariants.

## Changes

- `Feedback#initialize` freezes `suggestions`
- `Scorer#build_score` freezes `sequence`, `crack_times_seconds`, and `crack_times_display`
- `MatchBuilder#build` freezes `sub`
- `Trie#freeze` converted from recursive to iterative traversal
- New `spec/zxcvbn/thread_safety_spec.rb` covering concurrent `Zxcvbn.test`, `FrozenError` assertions on every nested collection, and concurrent `default_tester` initialization

## Consequences

Mutating any nested collection on a returned `Score`, `Match`, or `Feedback` now raises `FrozenError`. The trie freeze is safe for arbitrarily long words. The thread-safety invariants are now regression-tested.