### PR TITLE
Validate TesterBuilder inputs at the call site

### DIFF
--- a/lib/zxcvbn/tester_builder.rb
+++ b/lib/zxcvbn/tester_builder.rb
@@ -25,16 +25,24 @@ module Zxcvbn
     end
 
     # @param name [String] identifier for the word list; calling with the same name twice replaces the earlier list
-    # @param words [Array<String>] words to add
+    # @param words [Array<String>] words to add; non-String elements are silently ignored during matching
     # @return [self]
+    # @raise [ArgumentError] if words is not an Array
     def add_word_list(name, words)
+      raise ArgumentError, "words must be an Array; got #{words.inspect}" unless words.is_a?(Array)
+
       @word_lists[name] = words
       self
     end
 
     # @param length [Integer] maximum password length for the built {Tester}
     # @return [self]
+    # @raise [ArgumentError] if length is not a positive integer
     def max_password_length(length)
+      unless length.is_a?(Integer) && length.positive?
+        raise ArgumentError, "max_password_length must be a positive integer; got #{length.inspect}"
+      end
+
       @max_password_length = length
       self
     end
@@ -52,18 +60,17 @@ module Zxcvbn
     def effective_max_password_length
       return @max_password_length if @max_password_length
 
+      env_str = ENV['ZXCVBN_MAX_PASSWORD_LENGTH']
+      return DEFAULT_MAX_PASSWORD_LENGTH unless env_str
+
       value = begin
-        Integer(ENV.fetch('ZXCVBN_MAX_PASSWORD_LENGTH', DEFAULT_MAX_PASSWORD_LENGTH))
-      rescue ArgumentError, TypeError
-        raise ArgumentError,
-              'ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; ' \
-              "got #{ENV['ZXCVBN_MAX_PASSWORD_LENGTH'].inspect}"
+        Integer(env_str, 10)
+      rescue ArgumentError
+        raise ArgumentError, "ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; got #{env_str.inspect}"
       end
 
       unless value.positive?
-        raise ArgumentError,
-              'ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; ' \
-              "got #{ENV['ZXCVBN_MAX_PASSWORD_LENGTH'].inspect}"
+        raise ArgumentError, "ZXCVBN_MAX_PASSWORD_LENGTH must be a positive integer; got #{env_str.inspect}"
       end
 
       value

--- a/spec/zxcvbn/tester_builder_spec.rb
+++ b/spec/zxcvbn/tester_builder_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe Zxcvbn::TesterBuilder do
       expect(Zxcvbn.tester.build.max_password_length).to eq 50
     end
 
+    it 'parses ZXCVBN_MAX_PASSWORD_LENGTH as base 10, not octal' do
+      stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '010' })
+      expect(Zxcvbn.tester.build.max_password_length).to eq 10
+    end
+
     it 'ignores ZXCVBN_MAX_PASSWORD_LENGTH when an explicit value is set' do
       stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '50' })
       expect(Zxcvbn.tester.max_password_length(10).build.max_password_length).to eq 10
@@ -63,7 +68,15 @@ RSpec.describe Zxcvbn::TesterBuilder do
     end
 
     it 'raises ArgumentError for non-positive max_password_length' do
-      expect { Zxcvbn.tester.max_password_length(0).build }.to raise_error(ArgumentError)
+      expect { Zxcvbn.tester.max_password_length(0) }.to raise_error(ArgumentError)
+    end
+
+    it 'raises ArgumentError for nil max_password_length' do
+      expect { Zxcvbn.tester.max_password_length(nil) }.to raise_error(ArgumentError)
+    end
+
+    it 'raises ArgumentError for non-Array words in add_word_list' do
+      expect { Zxcvbn.tester.add_word_list('test', nil) }.to raise_error(ArgumentError)
     end
 
     it 'accumulates multiple add_word_list calls' do


### PR DESCRIPTION
## Context

`TesterBuilder#add_word_list` accepts any value for `words` and stores it without validation. Passing `nil` produces a `NoMethodError` inside `Data#add_word_list` at build time, far from the call site. `TesterBuilder#max_password_length` accepts any value including `nil`, which silently falls through to the env var path as if the setter had never been called. `ZXCVBN_MAX_PASSWORD_LENGTH` is parsed with `Integer()`, which treats leading zeros as octal (e.g. `"010"` → 8).

## Changes

- `add_word_list` raises `ArgumentError` immediately if `words` is not an Array
- `max_password_length` raises `ArgumentError` immediately if `length` is not a positive integer, catching `nil` and wrong types at the call site
- `effective_max_password_length` uses `Integer(env_str, 10)` to parse the env var as base 10
- Specs added for all three cases

## Consequences

Invalid inputs to `TesterBuilder` raise `ArgumentError` at the call site rather than producing confusing errors later. `ZXCVBN_MAX_PASSWORD_LENGTH=010` is now interpreted as 10, not 8.