### PR TITLE
Avoid O(n³) string copies in bruteforce DP segments

### DIFF
--- a/lib/zxcvbn/guesses.rb
+++ b/lib/zxcvbn/guesses.rb
@@ -35,9 +35,10 @@ module Zxcvbn
     def estimate_guesses(match, password)
       return match.guesses if match.guesses
 
+      token_length = match.token ? match.token.length : match.j - match.i + 1
       min_guesses =
-        if match.token.length < password.length
-          match.token.length == 1 ? MIN_SUBMATCH_GUESSES_SINGLE_CHAR : MIN_SUBMATCH_GUESSES_MULTI_CHAR
+        if token_length < password.length
+          token_length == 1 ? MIN_SUBMATCH_GUESSES_SINGLE_CHAR : MIN_SUBMATCH_GUESSES_MULTI_CHAR
         else
           1
         end
@@ -63,9 +64,10 @@ module Zxcvbn
     # @param match [MatchBuilder] a bruteforce match
     # @return [Numeric] guesses based on token length and assumed cardinality
     def bruteforce_guesses(match)
-      guesses = BRUTEFORCE_CARDINALITY**match.token.length.to_f
+      length = match.token ? match.token.length : match.j - match.i + 1
+      guesses = BRUTEFORCE_CARDINALITY**length.to_f
       guesses = Float::MAX if guesses.infinite?
-      min = match.token.length == 1 ? MIN_SUBMATCH_GUESSES_SINGLE_CHAR + 1.0 : MIN_SUBMATCH_GUESSES_MULTI_CHAR + 1.0
+      min = length == 1 ? MIN_SUBMATCH_GUESSES_SINGLE_CHAR + 1.0 : MIN_SUBMATCH_GUESSES_MULTI_CHAR + 1.0
       [guesses, min].max
     end
 

--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -93,7 +93,7 @@ module Zxcvbn
       end
 
       make_bruteforce = lambda do |i, j|
-        MatchBuilder.new(pattern: 'bruteforce', token: password.slice(i, j - i + 1), i:, j:)
+        MatchBuilder.new(pattern: 'bruteforce', i:, j:)
       end
 
       (0...n).each do |k|
@@ -125,6 +125,7 @@ module Zxcvbn
       l = optimal_l
       while k >= 0
         match = m[k][l]
+        match.token ||= password.slice(match.i, match.j - match.i + 1)
         sequence.unshift(match.build)
         k = match.i - 1
         l -= 1


### PR DESCRIPTION
## Context

The DP scorer calls `make_bruteforce` for every `(i, j)` pair when exploring bruteforce segments — O(n²) calls, each copying a substring via `password.slice`. Near the 256-character cap this is O(n³) bytes copied per scoring call, with most substrings discarded immediately by the dominance check.

## Changes

- `make_bruteforce` no longer sets `token`
- `bruteforce_guesses` and `estimate_guesses` fall back to `j - i + 1` when `token` is nil
- The backtrack step sets the token before calling `build`, so only the O(n) surviving matches pay for the slice

## Consequences

String allocation in the bruteforce hot path drops from O(n²) substrings to O(n) (the matches that make the optimal sequence). The change is confined to three small call sites with no impact on correctness or the public API.