### PR TITLE
Suppress large inspect output on Data and Trie

### DIFF
--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -19,7 +19,9 @@ module Zxcvbn
     private_constant :DATA_PATH
 
     # Consistent named pair of ranked dictionaries and their tries.
-    Dictionaries = ::Data.define(:ranked, :tries)
+    Dictionaries = ::Data.define(:ranked, :tries) do
+      def inspect = "#<#{self.class}:0x#{__id__.to_s(16)}>"
+    end
     private_constant :Dictionaries
 
     # Loads all built-in frequency lists and adjacency graphs from disk.
@@ -42,6 +44,8 @@ module Zxcvbn
     end
 
     attr_reader :adjacency_graphs, :graph_stats, :dictionaries
+
+    def inspect = "#<#{self.class}:0x#{__id__.to_s(16)}>"
 
     # @return [Hash{String => Hash{String => Integer}}] word → rank maps
     def ranked_dictionaries = @dictionaries.ranked

--- a/lib/zxcvbn/trie.rb
+++ b/lib/zxcvbn/trie.rb
@@ -51,6 +51,8 @@ module Zxcvbn
       results
     end
 
+    def inspect = "#<#{self.class}:0x#{__id__.to_s(16)}>"
+
     def freeze
       stack = [@root]
       while (node = stack.pop)


### PR DESCRIPTION
## Context

`Tester#inspect` is already masked to return a short address string, but `Data#inspect` is not. `FrozenError` messages raised when `add_word_list` is called on a frozen `Data` instance embed the full default `inspect` output — approximately 5.6 MB of dictionary contents. This is hostile to log shippers, exception reporters, and IRB.

## Changes

- `Data#inspect` returns `#<Zxcvbn::Data:0xADDR>`
- `Data::Dictionaries#inspect` returns the same short form
- `Trie#inspect` returns the same short form

## Consequences

Exception messages and log output involving these objects are no longer multi-megabyte. Matches the pattern already established on `Tester`.