### PR TITLE
Create `zxcvbn/ruby.rb`

### DIFF
--- a/lib/zxcvbn/ruby.rb
+++ b/lib/zxcvbn/ruby.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'zxcvbn'


### PR DESCRIPTION
To go from

```
gem "zxcvbn-ruby", require: "zxcvbn"
```

To:

```
gem "zxcvbn-ruby"
```