### PR TITLE
Rename `Zxcvbn.tester` to `Zxcvbn.tester_builder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - User-input dictionary matchers now use the Trie path, preventing O(n²) slowdowns on long passwords ([#89])
 
 ### Added
- - `Zxcvbn::TesterBuilder`: fluent builder for constructing a `Tester` with custom word lists and options. Obtain a builder via `Zxcvbn.tester`, then chain `add_word_list`, `max_password_length`, and `build`.
+ - `Zxcvbn::TesterBuilder`: fluent builder for constructing a `Tester` with custom word lists and options. Obtain a builder via `Zxcvbn.tester_builder`, then chain `add_word_list`, `max_password_length`, and `build`.
  - `Zxcvbn::Guesses` module with per-pattern guess estimation formulas matching zxcvbn.js v4: bruteforce, dictionary (with uppercase and l33t variation multipliers), spatial, repeat, sequence, digits, year, and date ([#69])
  - `us_tv_and_film` frequency list (19,160 entries) introduced in zxcvbn.js v4 ([#69])
  - Reverse dictionary matching in `Omnimatch` so reversed words (e.g. "drowssap") are detected and scored ([#69])
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - YARD documentation for all public classes, modules, and methods ([#72])
 
 ### Changed
- - **Breaking**: `Zxcvbn::Tester.new` now requires `data:` and `max_password_length:` keyword arguments with no defaults. Use `Zxcvbn.tester.build` to construct a `Tester`.
+ - **Breaking**: `Zxcvbn::Tester.new` now requires `data:` and `max_password_length:` keyword arguments with no defaults. Use `Zxcvbn.tester_builder.build` to construct a `Tester`.
  - **Breaking**: English frequency list dictionary name renamed from `english` to `english_wikipedia`, matching the zxcvbn.js source. Affects `match.dictionary_name` in results ([#90])
  - `Zxcvbn.test` now reuses a shared `Tester` instance across calls, avoiding repeated dictionary parsing ([#80])
  - Repeat base tokens are now scored without `user_inputs`, matching zxcvbn.js v4. Previously, user-supplied words were propagated into the recursive scoring of a repeat's base token, causing repeat matches of user-supplied words to score lower than JS would report ([#83])
@@ -43,11 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Repeat feedback now distinguishes single-char repeats (`"aaa"`) from multi-char repeats (`"abcabcabc"`), matching zxcvbn.js v4 ([#69])
  - `year` pattern matches now produce a "Recent years are easy to guess" warning ([#69])
  - Sole matches from the `english_wikipedia` dictionary now produce an "A word by itself is easy to guess" warning ([#69])
- - **Breaking**: `Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than 256 characters (the default). Previously, long passwords were accepted and could cause super-quadratic runtime on adversarial repeat inputs to the `password` argument. The `user_inputs` parameter remains unbounded. Override the limit with the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable or `Zxcvbn.tester.max_password_length(n).build`.
+ - **Breaking**: `Tester#test` and `Zxcvbn.test` now raise `Zxcvbn::PasswordTooLong` (a subclass of `ArgumentError`) for passwords longer than 256 characters (the default). Previously, long passwords were accepted and could cause super-quadratic runtime on adversarial repeat inputs to the `password` argument. The `user_inputs` parameter remains unbounded. Override the limit with the `ZXCVBN_MAX_PASSWORD_LENGTH` environment variable or `Zxcvbn.tester_builder.max_password_length(n).build`.
 
 ### Removed
- - **Breaking**: `Tester#add_word_lists`. Use `Zxcvbn.tester.add_word_list(name, words).build` instead.
- - **Breaking**: `word_lists:` argument to `Zxcvbn.test`. Use `Zxcvbn.tester.add_word_list(name, words).build` to construct a tester with custom word lists.
+ - **Breaking**: `Tester#add_word_lists`. Use `Zxcvbn.tester_builder.add_word_list(name, words).build` instead.
+ - **Breaking**: `word_lists:` argument to `Zxcvbn.test`. Use `Zxcvbn.tester_builder.add_word_list(name, words).build` to construct a tester with custom word lists.
  - Support for Ruby versions below 3.3 ([#70])
 
 

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ $ irb
 
 ## Custom Testers
 
-`Zxcvbn.test` reuses a shared `Tester` internally — dictionaries are loaded once and persist in memory. Use `Zxcvbn.tester.build` to construct a standalone `Tester` you control:
+`Zxcvbn.test` reuses a shared `Tester` internally — dictionaries are loaded once and persist in memory. Use `Zxcvbn.tester_builder.build` to construct a standalone `Tester` you control:
 
 ```ruby
 $ irb
 >> require 'zxcvbn'
 => true
->> tester = Zxcvbn.tester.build
+>> tester = Zxcvbn.tester_builder.build
 => #<Zxcvbn::Tester:0x3fe99d869aa4>
 >> pp tester.test('@lfred2004', ['alfred'])
 #<data Zxcvbn::Score
@@ -168,7 +168,7 @@ $ irb
 To add custom word lists, chain `add_word_list` before `build`. Use a distinct name (e.g. `"company"`) — using a built-in name (`"english_wikipedia"`, `"passwords"`, `"female_names"`, `"male_names"`, `"surnames"`, `"us_tv_and_film"`) replaces that list entirely:
 
 ```ruby
->> tester = Zxcvbn.tester.add_word_list('company', %w[acme corp]).build
+>> tester = Zxcvbn.tester_builder.add_word_list('company', %w[acme corp]).build
 => #<Zxcvbn::Tester:0x3fe99d869bb8>
 >> tester.test('acme').score
 => 0
@@ -319,7 +319,7 @@ result = Zxcvbn.test(password)
 To use a different limit for a specific tester without touching the environment:
 
 ```ruby
-tester = Zxcvbn.tester.max_password_length(128).build
+tester = Zxcvbn.tester_builder.max_password_length(128).build
 result = tester.test(password)
 ```
 
@@ -335,7 +335,7 @@ Or export it from your shell profile, process manager, or platform environment c
 
 ### Custom word lists
 
-`Tester#add_word_lists` and the `word_lists:` argument to `Zxcvbn.test` have been removed. Use the `Zxcvbn.tester` builder instead:
+`Tester#add_word_lists` and the `word_lists:` argument to `Zxcvbn.test` have been removed. Use the `Zxcvbn.tester_builder` builder instead:
 
 ```ruby
 # 1.x — no longer works
@@ -343,18 +343,18 @@ result = Zxcvbn.test(password, user_inputs, word_lists: { 'company' => %w[acme c
 tester.add_word_lists('company' => %w[acme corp])
 
 # 2.x
-tester = Zxcvbn.tester.add_word_list('company', %w[acme corp]).build
+tester = Zxcvbn.tester_builder.add_word_list('company', %w[acme corp]).build
 result = tester.test(password, user_inputs)
 ```
 
-`Zxcvbn::Tester.new` is no longer a public construction path — it now requires `data:` and `max_password_length:` keyword arguments with no defaults. Use `Zxcvbn.tester.build` (or the fluent builder) instead:
+`Zxcvbn::Tester.new` is no longer a public construction path — it now requires `data:` and `max_password_length:` keyword arguments with no defaults. Use `Zxcvbn.tester_builder.build` (or the fluent builder) instead:
 
 ```ruby
 # 1.x
 tester = Zxcvbn::Tester.new
 
 # 2.x
-tester = Zxcvbn.tester.build
+tester = Zxcvbn.tester_builder.build
 ```
 
 ### Score values will change

--- a/lib/zxcvbn.rb
+++ b/lib/zxcvbn.rb
@@ -19,12 +19,12 @@ module Zxcvbn
   # Returns a Zxcvbn::Score for the given password.
   #
   # Reuses a shared {Tester} instance across calls. For custom word lists or
-  # options, use {.tester} to build a dedicated {Tester}.
+  # options, use {.tester_builder} to build a dedicated {Tester}.
   #
   # Raises {PasswordTooLong} (a subclass of +ArgumentError+) if the password
   # exceeds the configured limit (default: 256 characters). Override process-wide
   # via the +ZXCVBN_MAX_PASSWORD_LENGTH+ environment variable; for per-call limits,
-  # use {.tester} with {TesterBuilder#max_password_length}.
+  # use {.tester_builder} with {TesterBuilder#max_password_length}.
   #
   # Example:
   #
@@ -43,19 +43,20 @@ module Zxcvbn
   #
   # Example:
   #
-  #   tester = Zxcvbn.tester
+  #   tester = Zxcvbn
+  #     .tester_builder
   #     .add_word_list('company', %w[acme corp])
   #     .max_password_length(75)
   #     .build
   #
   # @return [TesterBuilder]
-  def tester
+  def tester_builder
     TesterBuilder.new
   end
 
   # @return [Tester] the shared default tester, constructed on first call
   def default_tester
-    DEFAULT_TESTER_MUTEX.synchronize { @default_tester ||= tester.build }
+    DEFAULT_TESTER_MUTEX.synchronize { @default_tester ||= tester_builder.build }
   end
   private_class_method :default_tester
 end

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -12,9 +12,10 @@ module Zxcvbn
   class PasswordTooLong < ArgumentError; end
 
   # Evaluates password strength against dictionary lists, keyboard patterns,
-  # dates, sequences, and repeats. Construct via {Zxcvbn.tester}:
+  # dates, sequences, and repeats. Construct via {Zxcvbn.tester_builder}:
   #
-  #   tester = Zxcvbn.tester
+  #   tester = Zxcvbn
+  #     .tester_builder
   #     .add_word_list('company', %w[acme corp])
   #     .build
   #

--- a/lib/zxcvbn/tester_builder.rb
+++ b/lib/zxcvbn/tester_builder.rb
@@ -6,11 +6,12 @@ require 'zxcvbn/tester'
 module Zxcvbn
   # Fluent builder for constructing a {Tester} with custom word lists and options.
   #
-  # Obtain a builder via {Zxcvbn.tester} and call {#build} to get the {Tester}.
+  # Obtain a builder via {Zxcvbn.tester_builder} and call {#build} to get the {Tester}.
   #
   # Example:
   #
-  #   tester = Zxcvbn.tester
+  #   tester = Zxcvbn
+  #     .tester_builder
   #     .add_word_list('company', %w[acme corp])
   #     .max_password_length(75)
   #     .build

--- a/sig/zxcvbn.rbs
+++ b/sig/zxcvbn.rbs
@@ -8,5 +8,5 @@ module Zxcvbn
 
   def self.test: (String? password, ?user_inputs user_inputs) -> Score
 
-  def self.tester: () -> TesterBuilder
+  def self.tester_builder: () -> TesterBuilder
 end

--- a/spec/zxcvbn/tester_builder_spec.rb
+++ b/spec/zxcvbn/tester_builder_spec.rb
@@ -3,84 +3,84 @@
 require 'spec_helper'
 
 RSpec.describe Zxcvbn::TesterBuilder do
-  describe 'Zxcvbn.tester' do
+  describe 'Zxcvbn.tester_builder' do
     it 'returns a Builder' do
-      expect(Zxcvbn.tester).to be_a(Zxcvbn::TesterBuilder)
+      expect(Zxcvbn.tester_builder).to be_a(Zxcvbn::TesterBuilder)
     end
 
     it 'returns a new Builder on each call' do
-      expect(Zxcvbn.tester).not_to be(Zxcvbn.tester)
+      expect(Zxcvbn.tester_builder).not_to be(Zxcvbn.tester_builder)
     end
   end
 
   describe '#build' do
     it 'returns a Tester' do
-      expect(Zxcvbn.tester.build).to be_a(Zxcvbn::Tester)
+      expect(Zxcvbn.tester_builder.build).to be_a(Zxcvbn::Tester)
     end
 
     it 'returns a frozen Tester' do
-      expect(Zxcvbn.tester.build).to be_frozen
+      expect(Zxcvbn.tester_builder.build).to be_frozen
     end
 
     it 'uses the default max_password_length when none is set' do
-      expect(Zxcvbn.tester.build.max_password_length).to eq Zxcvbn::TesterBuilder::DEFAULT_MAX_PASSWORD_LENGTH
+      expect(Zxcvbn.tester_builder.build.max_password_length).to eq Zxcvbn::TesterBuilder::DEFAULT_MAX_PASSWORD_LENGTH
     end
 
     it 'raises ArgumentError when ZXCVBN_MAX_PASSWORD_LENGTH is not an integer' do
       stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => 'abc' })
-      expect { Zxcvbn.tester.build }.to raise_error(ArgumentError)
+      expect { Zxcvbn.tester_builder.build }.to raise_error(ArgumentError)
     end
 
     it 'raises ArgumentError when ZXCVBN_MAX_PASSWORD_LENGTH is non-positive' do
       stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '0' })
-      expect { Zxcvbn.tester.build }.to raise_error(ArgumentError)
+      expect { Zxcvbn.tester_builder.build }.to raise_error(ArgumentError)
     end
 
     it 'reads max_password_length from ZXCVBN_MAX_PASSWORD_LENGTH when none is set' do
       stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '50' })
-      expect(Zxcvbn.tester.build.max_password_length).to eq 50
+      expect(Zxcvbn.tester_builder.build.max_password_length).to eq 50
     end
 
     it 'parses ZXCVBN_MAX_PASSWORD_LENGTH as base 10, not octal' do
       stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '010' })
-      expect(Zxcvbn.tester.build.max_password_length).to eq 10
+      expect(Zxcvbn.tester_builder.build.max_password_length).to eq 10
     end
 
     it 'ignores ZXCVBN_MAX_PASSWORD_LENGTH when an explicit value is set' do
       stub_const('ENV', { 'ZXCVBN_MAX_PASSWORD_LENGTH' => '50' })
-      expect(Zxcvbn.tester.max_password_length(10).build.max_password_length).to eq 10
+      expect(Zxcvbn.tester_builder.max_password_length(10).build.max_password_length).to eq 10
     end
 
     it 'honours a custom max_password_length' do
-      tester = Zxcvbn.tester.max_password_length(10).build
+      tester = Zxcvbn.tester_builder.max_password_length(10).build
       expect { tester.test('a' * 10) }.not_to raise_error
       expect { tester.test('a' * 11) }.to raise_error(Zxcvbn::PasswordTooLong)
     end
 
     it 'applies an added word list' do
-      tester = Zxcvbn.tester.add_word_list('envato', ['envato']).build
+      tester = Zxcvbn.tester_builder.add_word_list('envato', ['envato']).build
       expect(tester.test('envato').score).to eq 0
     end
 
     it 'returns independent testers on each build' do
-      builder = Zxcvbn.tester
+      builder = Zxcvbn.tester_builder
       expect(builder.build).not_to be(builder.build)
     end
 
     it 'raises ArgumentError for non-positive max_password_length' do
-      expect { Zxcvbn.tester.max_password_length(0) }.to raise_error(ArgumentError)
+      expect { Zxcvbn.tester_builder.max_password_length(0) }.to raise_error(ArgumentError)
     end
 
     it 'raises ArgumentError for nil max_password_length' do
-      expect { Zxcvbn.tester.max_password_length(nil) }.to raise_error(ArgumentError)
+      expect { Zxcvbn.tester_builder.max_password_length(nil) }.to raise_error(ArgumentError)
     end
 
     it 'raises ArgumentError for non-Array words in add_word_list' do
-      expect { Zxcvbn.tester.add_word_list('test', nil) }.to raise_error(ArgumentError)
+      expect { Zxcvbn.tester_builder.add_word_list('test', nil) }.to raise_error(ArgumentError)
     end
 
     it 'accumulates multiple add_word_list calls' do
-      tester = Zxcvbn.tester
+      tester = Zxcvbn.tester_builder
                      .add_word_list('a', ['foo'])
                      .add_word_list('b', ['bar'])
                      .build
@@ -91,12 +91,12 @@ RSpec.describe Zxcvbn::TesterBuilder do
 
   describe 'method chaining' do
     it 'add_word_list returns self' do
-      builder = Zxcvbn.tester
+      builder = Zxcvbn.tester_builder
       expect(builder.add_word_list('x', [])).to be(builder)
     end
 
     it 'max_password_length returns self' do
-      builder = Zxcvbn.tester
+      builder = Zxcvbn.tester_builder
       expect(builder.max_password_length(10)).to be(builder)
     end
   end

--- a/spec/zxcvbn/tester_spec.rb
+++ b/spec/zxcvbn/tester_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Zxcvbn::Tester do
   end
 
   context 'with a custom global dictionary' do
-    let(:tester) { Zxcvbn.tester.add_word_list('envato', ['envato']).build }
+    let(:tester) { Zxcvbn.tester_builder.add_word_list('envato', ['envato']).build }
 
     it 'scores them against the dictionary' do
       result = tester.test('envato')
@@ -104,7 +104,7 @@ RSpec.describe Zxcvbn::Tester do
     end
 
     context 'with invalid entries in a custom dictionary' do
-      let(:tester) { Zxcvbn.tester.add_word_list('themeforest', [nil, 1, 'themeforest']).build }
+      let(:tester) { Zxcvbn.tester_builder.add_word_list('themeforest', [nil, 1, 'themeforest']).build }
 
       it 'ignores those entries' do
         expect(tester.test('themeforest')).to have_attributes(score: 0)
@@ -146,7 +146,7 @@ RSpec.describe Zxcvbn::Tester do
       # Use a high-entropy string so the whole password is a single bruteforce
       # match: length 400 → 10**400 → Float::MAX → crack time overflows to Infinity
       # without the clamp.
-      high_limit_tester = Zxcvbn.tester.max_password_length(400).build
+      high_limit_tester = Zxcvbn.tester_builder.max_password_length(400).build
       saved = srand(7)
       high_entropy = (1..400).map { rand(33..126).chr }.join
       srand(saved)
@@ -168,7 +168,7 @@ RSpec.describe Zxcvbn::Tester do
   end
 
   context 'with a custom max_password_length' do
-    let(:tester) { Zxcvbn.tester.max_password_length(10).build }
+    let(:tester) { Zxcvbn.tester_builder.max_password_length(10).build }
 
     it 'accepts passwords at the custom limit' do
       expect { tester.test('a' * 10) }.not_to raise_error


### PR DESCRIPTION
## Context

`Zxcvbn.tester` returns a fresh `TesterBuilder` on every call. The name reads like a singleton accessor — implying it returns the current default `Tester` — which is not what it does.

## Changes

Rename `Zxcvbn.tester` → `Zxcvbn.tester_builder` across the library, specs, README, and CHANGELOG.

## Consequences

The name now matches the class it returns (`TesterBuilder`) and signals construction rather than access. This is a breaking change for any caller using `Zxcvbn.tester`.