### PR TITLE
Tidy gem metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zxcvbn-ruby
 
-This is a Ruby port of Dropbox's [zxcvbn.js][zxcvbn.js] JavaScript library, targeting **zxcvbn.js v4** and aiming to produce identical results.
+This is a Ruby port of Dropbox's [zxcvbn.js][zxcvbn.js] JavaScript password strength estimator, providing **zxcvbn.js v4** compatibility.
 
 ## Development status [![CI Status](https://github.com/envato/zxcvbn-ruby/workflows/CI/badge.svg)](https://github.com/envato/zxcvbn-ruby/actions?query=workflow%3ACI)
 

--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ Audit any code that gates on `result.score` (e.g. form validation thresholds), p
 
  - [Steve Hodgkiss](https://github.com/stevehodgkiss)
  - [Matthieu Aussaguel](https://github.com/matthieua)
+ - [Orien Madgwick](https://github.com/orien)
  - [_et al._](https://github.com/envato/zxcvbn-ruby/graphs/contributors?all=1)
 
 ## License [![license](https://img.shields.io/github/license/mashape/apistatus.svg?style=flat-square)](https://github.com/envato/zxcvbn-ruby/blob/HEAD/LICENSE.txt)

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |gem|
   gem.version     = Zxcvbn::VERSION
   gem.description = 'Ruby port of Dropboxs zxcvbn.js'
   gem.summary     = ''
-  gem.authors     = ['Steve Hodgkiss', 'Matthieu Aussaguel']
-  gem.email       = ['steve@hodgkiss.me', 'matthieu.aussaguel@gmail.com']
+  gem.authors     = ['Steve Hodgkiss', 'Matthieu Aussaguel', 'Orien Madgwick']
+  gem.email       = ['steve@hodgkiss.me', 'matthieu.aussaguel@gmail.com', '_@orien.io']
   gem.homepage    = "https://github.com/envato/#{gem.name}"
   gem.license     = 'MIT'
 

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -5,8 +5,9 @@ require File.expand_path('lib/zxcvbn/version', __dir__)
 Gem::Specification.new do |gem|
   gem.name        = 'zxcvbn-ruby'
   gem.version     = Zxcvbn::VERSION
-  gem.description = 'Ruby port of Dropboxs zxcvbn.js'
-  gem.summary     = ''
+  gem.summary     = "Ruby port of Dropbox's zxcvbn.js JavaScript password strength estimator"
+  gem.description = "Ruby port of Dropbox's zxcvbn.js JavaScript password strength estimator, " \
+                    'providing v4 compatibility.'
   gem.authors     = ['Steve Hodgkiss', 'Matthieu Aussaguel', 'Orien Madgwick']
   gem.email       = ['steve@hodgkiss.me', 'matthieu.aussaguel@gmail.com', '_@orien.io']
   gem.homepage    = "https://github.com/envato/#{gem.name}"

--- a/zxcvbn-ruby.gemspec
+++ b/zxcvbn-ruby.gemspec
@@ -3,21 +3,14 @@
 require File.expand_path('lib/zxcvbn/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ['Steve Hodgkiss', 'Matthieu Aussaguel']
-  gem.email         = ['steve@hodgkiss.me', 'matthieu.aussaguel@gmail.com']
-  gem.description   = 'Ruby port of Dropboxs zxcvbn.js'
-  gem.summary       = ''
-  gem.homepage      = 'https://github.com/envato/zxcvbn-ruby'
-
-  gem.files         = `git ls-files -z`.split("\x0").reject do |file|
-    file.match(%r{^(\.|CODE_OF_CONDUCT.md|Gemfile|Rakefile|Guardfile|zxcvbn-ruby.gemspec|rbs_collection.yaml|spec/)})
-  end
-  gem.name          = 'zxcvbn-ruby'
-  gem.require_paths = ['lib']
-  gem.version       = Zxcvbn::VERSION
-  gem.license       = 'MIT'
-
-  gem.required_ruby_version = '>= 3.3'
+  gem.name        = 'zxcvbn-ruby'
+  gem.version     = Zxcvbn::VERSION
+  gem.description = 'Ruby port of Dropboxs zxcvbn.js'
+  gem.summary     = ''
+  gem.authors     = ['Steve Hodgkiss', 'Matthieu Aussaguel']
+  gem.email       = ['steve@hodgkiss.me', 'matthieu.aussaguel@gmail.com']
+  gem.homepage    = "https://github.com/envato/#{gem.name}"
+  gem.license     = 'MIT'
 
   gem.metadata = {
     'allowed_push_host' => 'https://rubygems.org',
@@ -28,4 +21,12 @@ Gem::Specification.new do |gem|
     'source_code_uri' => "#{gem.homepage}/tree/v#{gem.version}",
     'rubygems_mfa_required' => 'true'
   }
+
+  gem.required_ruby_version = '>= 3.3'
+
+  gem.require_paths = ['lib']
+
+  gem.files = `git ls-files -z`.split("\x0").reject do |file|
+    file.match(%r{^(\.|CODE_OF_CONDUCT.md|Gemfile|Rakefile|Guardfile|zxcvbn-ruby.gemspec|rbs_collection.yaml|spec/)})
+  end
 end


### PR DESCRIPTION
## Context

The gemspec has accumulated some rough edges: empty summary, a missing apostrophe in "Dropbox's", and fields in a non-standard order. The README intro uses hedged language ("targeting … aiming to produce identical results") that undersells the gem's maturity.

## Changes

- Reorder gemspec fields to conventional RubyGems ordering
- Use `gem.name` interpolation for the homepage URL
- Add Orien Madgwick to authors (gemspec and README)
- Fill in `gem.summary` and improve `gem.description` with accurate, confident wording
- Update README intro to match

## Consequences

Cosmetic only — no functional changes.