### PR TITLE
Coerce user_inputs to Array[String] at public boundaries

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,6 +20,7 @@ Metrics/AbcSize:
     - 'lib/zxcvbn/matchers/spatial.rb'
     - 'lib/zxcvbn/omnimatch.rb'
     - 'lib/zxcvbn/scorer.rb'
+    - 'lib/zxcvbn/tester.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
 # AllowedMethods: refine

--- a/lib/zxcvbn/data.rb
+++ b/lib/zxcvbn/data.rb
@@ -59,7 +59,7 @@ module Zxcvbn
     # @param list [Array<String>] ordered words (most common first)
     # @return [void]
     def add_word_list(name, list)
-      ranked_dict = DictionaryRanker.rank_dictionary(list.select { |w| w.respond_to?(:downcase) }).freeze
+      ranked_dict = DictionaryRanker.rank_dictionary(list.select { |w| w.is_a?(String) }).freeze
       trie = Trie.from_ranked(ranked_dict).freeze
       @dictionaries = @dictionaries.with(
         ranked: @dictionaries.ranked.merge(name => ranked_dict).freeze,

--- a/lib/zxcvbn/omnimatch.rb
+++ b/lib/zxcvbn/omnimatch.rb
@@ -37,7 +37,6 @@ module Zxcvbn
     #   candidate; shared with the scorer so both phases agree even across midnight
     # @return [Array<MatchBuilder>]
     def matches(password, user_inputs = [], reference_year: Time.now.year)
-      user_inputs = user_inputs.select { |i| i.respond_to?(:downcase) }
       user_dictionary =
         user_inputs.any? && Matchers::Dictionary.new('user_inputs', DictionaryRanker.rank_dictionary(user_inputs))
       matchers = @matchers + user_input_matchers(user_dictionary)

--- a/lib/zxcvbn/tester.rb
+++ b/lib/zxcvbn/tester.rb
@@ -52,6 +52,7 @@ module Zxcvbn
     # @raise [PasswordTooLong] if the password exceeds the maximum length
     def test(password, user_inputs = [])
       password ||= ''
+      user_inputs = Array(user_inputs).select { |i| i.is_a?(String) }
       if password.length > @max_password_length
         raise PasswordTooLong, "Password exceeds the maximum length of #{@max_password_length}."
       end

--- a/lib/zxcvbn/tester_builder.rb
+++ b/lib/zxcvbn/tester_builder.rb
@@ -26,13 +26,10 @@ module Zxcvbn
     end
 
     # @param name [String] identifier for the word list; calling with the same name twice replaces the earlier list
-    # @param words [Array<String>] words to add; non-String elements are silently ignored during matching
+    # @param words [Array<String>, String] words to add; non-String elements are silently ignored during matching
     # @return [self]
-    # @raise [ArgumentError] if words is not an Array
     def add_word_list(name, words)
-      raise ArgumentError, "words must be an Array; got #{words.inspect}" unless words.is_a?(Array)
-
-      @word_lists[name] = words
+      @word_lists[name] = Array(words)
       self
     end
 

--- a/sig/zxcvbn/omnimatch.rbs
+++ b/sig/zxcvbn/omnimatch.rbs
@@ -6,7 +6,7 @@ module Zxcvbn
 
     def initialize: (Data data) -> void
 
-    def matches: (String password, ?Array[untyped] user_inputs, ?reference_year: Integer) -> Array[MatchBuilder]
+    def matches: (String password, ?Array[String] user_inputs, ?reference_year: Integer) -> Array[MatchBuilder]
 
     private
 

--- a/sig/zxcvbn/tester.rbs
+++ b/sig/zxcvbn/tester.rbs
@@ -8,7 +8,7 @@ module Zxcvbn
 
     attr_reader max_password_length: Integer
 
-    def test: (String? password, ?Array[untyped] user_inputs) -> Score
+    def test: (String? password, ?(Array[untyped] | String)? user_inputs) -> Score
 
     def inspect: () -> String
   end

--- a/sig/zxcvbn/tester_builder.rbs
+++ b/sig/zxcvbn/tester_builder.rbs
@@ -7,7 +7,7 @@ module Zxcvbn
 
     def initialize: () -> void
 
-    def add_word_list: (String name, Array[untyped] words) -> TesterBuilder
+    def add_word_list: (String name, ?(Array[untyped] | String)? words) -> TesterBuilder
 
     def max_password_length: (Integer length) -> TesterBuilder
 

--- a/spec/zxcvbn/tester_builder_spec.rb
+++ b/spec/zxcvbn/tester_builder_spec.rb
@@ -75,8 +75,19 @@ RSpec.describe Zxcvbn::TesterBuilder do
       expect { Zxcvbn.tester_builder.max_password_length(nil) }.to raise_error(ArgumentError)
     end
 
-    it 'raises ArgumentError for non-Array words in add_word_list' do
-      expect { Zxcvbn.tester_builder.add_word_list('test', nil) }.to raise_error(ArgumentError)
+    it 'treats nil words in add_word_list the same as an empty array' do
+      tester = Zxcvbn.tester_builder.add_word_list('test', nil).build
+      expect(tester.test('envato').guesses).to eq ZXCVBN_TESTER.test('envato').guesses
+    end
+
+    it 'accepts a single String in add_word_list' do
+      tester = Zxcvbn.tester_builder.add_word_list('envato', 'envato').build
+      expect(tester.test('envato').guesses).to be < ZXCVBN_TESTER.test('envato').guesses
+    end
+
+    it 'ignores non-String entries in add_word_list' do
+      tester_with_symbol = Zxcvbn.tester_builder.add_word_list('mixed', [:envato]).build
+      expect(tester_with_symbol.test('envato').guesses).to eq ZXCVBN_TESTER.test('envato').guesses
     end
 
     it 'accumulates multiple add_word_list calls' do

--- a/spec/zxcvbn/tester_spec.rb
+++ b/spec/zxcvbn/tester_spec.rb
@@ -124,6 +124,28 @@ RSpec.describe Zxcvbn::Tester do
     end
   end
 
+  context 'user_inputs coercion' do
+    it 'treats nil user_inputs the same as no user_inputs' do
+      expect(tester.test('themeforest', nil).guesses).to eq tester.test('themeforest').guesses
+    end
+
+    it 'accepts a single String as user_inputs' do
+      result_with = tester.test('themeforest', 'themeforest')
+      result_without = tester.test('themeforest')
+      expect(result_with.guesses).to be < result_without.guesses
+    end
+
+    it 'ignores non-String user_inputs such as symbols' do
+      expect(tester.test('themeforest', [:themeforest]).guesses).to eq tester.test('themeforest').guesses
+    end
+
+    it 'still uses valid String entries alongside ignored non-String ones' do
+      result_mixed = tester.test('themeforest', ['themeforest', :ignored, 42])
+      result_string_only = tester.test('themeforest', ['themeforest'])
+      expect(result_mixed.guesses).to eq result_string_only.guesses
+    end
+  end
+
   context 'with a very long password' do
     it 'accepts passwords at the length limit' do
       at_limit = 'a' * tester.max_password_length


### PR DESCRIPTION
## Context

The JS library coerces `null` user inputs to `[]` at the entry point (`null==t&&(t=[])`). Ruby has no equivalent guard. Passing `nil` as `user_inputs` to `Tester#test` raises `NoMethodError` (`nil.select`) inside `Omnimatch#matches`.

The `respond_to?(:downcase)` filter used to sanitise user inputs admits Symbols — `Symbol#downcase` exists in Ruby — but Symbols crash in `Trie#insert` on `each_char`. The same broken filter exists in `Data#add_word_list`, so `TesterBuilder#add_word_list('x', [:foo])` also crashes at build time.

## Changes

- `Tester#test`: coerce `user_inputs` via `Array(user_inputs).select { |i| i.is_a?(String) }`. Accepts `nil`, a single `String`, or a mixed array; non-Strings are silently ignored.
- `TesterBuilder#add_word_list`: same `Array()` coercion, removing the `ArgumentError` for non-Array input.
- `Omnimatch#matches`: remove the now-redundant filter; tighten RBS to `Array[String]`.
- Update RBS signatures for `Tester#test` and `TesterBuilder#add_word_list` to reflect the broader accepted types.

## Consequences

- `Tester#test(password, nil)` no longer raises.
- `Tester#test(password, [:foo, 42])` no longer crashes — non-Strings are silently ignored.
- `TesterBuilder#add_word_list('x', nil)` and `('x', 'word')` are accepted; nil is treated as an empty list.
- Callers previously relying on `ArgumentError` from `add_word_list(name, nil)` will no longer get one.