### PR TITLE
Return `guesses` as Float for empty password

### DIFF
--- a/lib/zxcvbn/scorer.rb
+++ b/lib/zxcvbn/scorer.rb
@@ -59,7 +59,7 @@ module Zxcvbn
     def most_guessable_match_sequence(password, matches, exclude_additive: false)
       n = password.length
 
-      return build_score(password, [], 1) if n.zero?
+      return build_score(password, [], 1.0) if n.zero?
 
       # index matches by their last character
       matches_by_j = Array.new(n) { [] }


### PR DESCRIPTION
## Context

`Zxcvbn.test('')` returns `guesses: 1` (Integer). All other passwords go through the DP scoring path and return `guesses` as Float. The JS library also returns `1` for empty password, so the value is correct — only the Ruby type is inconsistent.

## Changes

Change the empty-password short-circuit in `Scorer#most_guessable_match_sequence` from `1` to `1.0`.

## Consequences

`guesses` is now consistently Float across all inputs.