### PR TITLE
Fill test gaps in guesses_to_score, Scorer DP, and Guesses

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
 end
 
 TEST_PASSWORDS = [
+  '',
   'zxcvbn',
   'qwER43@!',
   'Tr0ub4dour&3',

--- a/spec/zxcvbn/crack_time_spec.rb
+++ b/spec/zxcvbn/crack_time_spec.rb
@@ -67,12 +67,36 @@ RSpec.describe Zxcvbn::CrackTime do
       expect(guesses_to_score(50_000)).to eq 1
     end
 
+    it 'returns 1 for 1_000_004 (last value inside the delta window for threshold 2)' do
+      expect(guesses_to_score(1_000_004)).to eq 1
+    end
+
+    it 'returns 2 for 1_000_005 (first value beyond the delta window for threshold 2)' do
+      expect(guesses_to_score(1_000_005)).to eq 2
+    end
+
     it 'returns 2 for 1_000_000–100_000_000 guesses' do
       expect(guesses_to_score(5_000_000)).to eq 2
     end
 
+    it 'returns 2 for 100_000_004 (last value inside the delta window for threshold 3)' do
+      expect(guesses_to_score(100_000_004)).to eq 2
+    end
+
+    it 'returns 3 for 100_000_005 (first value beyond the delta window for threshold 3)' do
+      expect(guesses_to_score(100_000_005)).to eq 3
+    end
+
     it 'returns 3 for 100_000_000–10_000_000_000 guesses' do
       expect(guesses_to_score(500_000_000)).to eq 3
+    end
+
+    it 'returns 3 for 10_000_000_004 (last value inside the delta window for threshold 4)' do
+      expect(guesses_to_score(10_000_000_004)).to eq 3
+    end
+
+    it 'returns 4 for 10_000_000_005 (first value beyond the delta window for threshold 4)' do
+      expect(guesses_to_score(10_000_000_005)).to eq 4
     end
 
     it 'returns 4 for 10_000_000_000 or more guesses' do

--- a/spec/zxcvbn/feedback_spec.rb
+++ b/spec/zxcvbn/feedback_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Zxcvbn::Feedback do
+  it 'defaults warning to an empty string' do
+    expect(described_class.new.warning).to eq ''
+  end
+
+  it 'coerces nil warning to an empty string' do
+    expect(described_class.new(warning: nil).warning).to eq ''
+  end
+
+  it 'defaults suggestions to an empty array' do
+    expect(described_class.new.suggestions).to eq []
+  end
+
+  it 'freezes suggestions' do
+    expect(described_class.new(suggestions: ['foo']).suggestions).to be_frozen
+  end
+
+  it 'supports structural equality' do
+    a = described_class.new(warning: 'w', suggestions: ['s'])
+    b = described_class.new(warning: 'w', suggestions: ['s'])
+    expect(a).to eq b
+  end
+end

--- a/spec/zxcvbn/guesses_spec.rb
+++ b/spec/zxcvbn/guesses_spec.rb
@@ -3,9 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe Zxcvbn::Guesses do
-  # Minimal host that satisfies the Guesses mixin contract.
-  # spatial_guesses additionally requires #data to supply graph stats,
-  # which is covered through integration tests in tester_spec.rb.
   let(:host) do
     Class.new do
       include Zxcvbn::Guesses
@@ -17,6 +14,19 @@ RSpec.describe Zxcvbn::Guesses do
         @reference_year = Time.now.year
       end
     end.new
+  end
+
+  let(:host_with_data) do
+    Class.new do
+      include Zxcvbn::Guesses
+
+      attr_reader :data
+
+      def initialize(data)
+        @data = data
+        @reference_year = Time.now.year
+      end
+    end.new(ZXCVBN_TEST_DATA)
   end
 
   def make_match(**attrs)
@@ -260,12 +270,42 @@ RSpec.describe Zxcvbn::Guesses do
       expect(host.estimate_guesses(m, '021297')).to eq 365 * 30
     end
 
+    it 'dispatches to spatial_guesses for spatial pattern' do
+      m = make_match(pattern: 'spatial', token: 'qwe', graph: 'qwerty', turns: 1, shifted_count: 0)
+      expect(host_with_data.estimate_guesses(m, 'qwe')).to be_positive
+    end
+
     it 'sets base_guesses, uppercase_variations, l33t_variations on dictionary matches' do
       m = make_match(pattern: 'dictionary', token: 'Pass', rank: 5, reversed: false, l33t: false)
       host.estimate_guesses(m, 'Pass')
       expect(m.base_guesses).to eq 5
       expect(m.uppercase_variations).to eq 2
       expect(m.l33t_variations).to eq 1
+    end
+  end
+
+  describe '#spatial_guesses' do
+    it 'returns a positive value for a straight qwerty path' do
+      m = make_match(token: 'qwe', graph: 'qwerty', turns: 1, shifted_count: 0)
+      expect(host_with_data.spatial_guesses(m)).to be_positive
+    end
+
+    it 'doubles guesses when all characters are shifted' do
+      unshifted = make_match(token: 'qwe', graph: 'qwerty', turns: 1, shifted_count: 0)
+      all_shifted = make_match(token: 'QWE', graph: 'qwerty', turns: 1, shifted_count: 3)
+      expect(host_with_data.spatial_guesses(all_shifted)).to eq host_with_data.spatial_guesses(unshifted) * 2
+    end
+
+    it 'produces more guesses for more turns' do
+      straight = make_match(token: 'qwer', graph: 'qwerty', turns: 1, shifted_count: 0)
+      curved   = make_match(token: 'qwer', graph: 'qwerty', turns: 3, shifted_count: 0)
+      expect(host_with_data.spatial_guesses(curved)).to be > host_with_data.spatial_guesses(straight)
+    end
+
+    it 'uses keypad stats for a keypad graph' do
+      qwerty_match = make_match(token: 'qwe', graph: 'qwerty', turns: 1, shifted_count: 0)
+      keypad_match = make_match(token: 'qwe', graph: 'keypad', turns: 1, shifted_count: 0)
+      expect(host_with_data.spatial_guesses(keypad_match)).not_to eq host_with_data.spatial_guesses(qwerty_match)
     end
   end
 end

--- a/spec/zxcvbn/score_spec.rb
+++ b/spec/zxcvbn/score_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Zxcvbn::Score do
+  let(:minimal) do
+    described_class.new(
+      password: 'test',
+      guesses: 100.0,
+      sequence: [],
+      crack_times_seconds: {},
+      crack_times_display: {},
+      score: 0
+    )
+  end
+
+  it 'defaults calc_time to nil' do
+    expect(minimal.calc_time).to be_nil
+  end
+
+  it 'defaults feedback to nil' do
+    expect(minimal.feedback).to be_nil
+  end
+
+  describe '#guesses_log10' do
+    it 'returns log10 of guesses' do
+      expect(minimal.guesses_log10).to be_within(1e-10).of(Math.log10(100.0))
+    end
+
+    it 'returns nil when guesses is nil' do
+      score = minimal.with(guesses: nil)
+      expect(score.guesses_log10).to be_nil
+    end
+  end
+
+  it 'supports structural equality' do
+    other = described_class.new(
+      password: 'test',
+      guesses: 100.0,
+      sequence: [],
+      crack_times_seconds: {},
+      crack_times_display: {},
+      score: 0
+    )
+    expect(minimal).to eq other
+  end
+end

--- a/spec/zxcvbn/scorer_spec.rb
+++ b/spec/zxcvbn/scorer_spec.rb
@@ -94,6 +94,28 @@ RSpec.describe Zxcvbn::Scorer do
         expect(result.sequence.last.token).to eq 'efgh'
       end
     end
+
+    context 'dominance pruning — two candidates at the same j and l' do
+      it 'keeps the cheaper match when a more expensive one arrives later' do
+        cheap = Zxcvbn::MatchBuilder.new(pattern: 'dictionary', i: 0, j: 3, token: 'abcd', rank: 1)
+        expensive = Zxcvbn::MatchBuilder.new(pattern: 'dictionary', i: 0, j: 3, token: 'abcd', rank: 500)
+        result = scorer.most_guessable_match_sequence('abcd', [cheap, expensive])
+        expect(result.sequence.length).to eq 1
+        expect(result.sequence.first).to have_attributes(rank: 1)
+        expect(result.guesses).to be < 500
+      end
+
+      it 'picks a length-1 sequence over a more expensive length-2 sequence at the same j' do
+        # single match covers full password cheaply
+        single = Zxcvbn::MatchBuilder.new(pattern: 'dictionary', i: 0, j: 5, token: 'abcdef', rank: 1)
+        # two-match path ending at j=5: first covers 'abc', second 'def', both rank=1 → more expensive
+        left  = Zxcvbn::MatchBuilder.new(pattern: 'dictionary', i: 0, j: 2, token: 'abc', rank: 1)
+        right = Zxcvbn::MatchBuilder.new(pattern: 'dictionary', i: 3, j: 5, token: 'def', rank: 1)
+        result = scorer.most_guessable_match_sequence('abcdef', [single, left, right])
+        expect(result.sequence.length).to eq 1
+        expect(result.sequence.first).to have_attributes(pattern: 'dictionary', i: 0, j: 5)
+      end
+    end
   end
 
   describe '#repeat_guesses' do


### PR DESCRIPTION
## Context

Several areas of the test suite have gaps that allow real bugs to go undetected:

- `guesses_to_score` has delta-boundary pairs only at the first of four thresholds — removing the `+ delta` fuzz from any of the other three threshold lines passes the full suite.
- The Scorer DP dominance pruning guard can be removed without breaking any test.
- `spatial_guesses` has no unit tests, and `Score` and `Feedback` have no dedicated specs.

## Changes

- Add delta-boundary pairs (`n_004`/`n_005`) for all four `guesses_to_score` thresholds.
- Add Scorer DP specs that force dominance pruning: two candidates at the same `j` and `l`, and a cheaper length-1 sequence that dominates a more expensive length-2 path at the same `j`.
- Add `spatial_guesses` unit tests covering shift doubling, turn scaling, and keypad vs qwerty graph stats.
- Add `score_spec.rb` and `feedback_spec.rb` covering initialisation defaults and structural equality for `Score` and `Feedback`.

## Consequences

Mutations to the `guesses_to_score` thresholds, the DP dominance guard, and the spatial guess formula will now be caught by the suite.