### PR TITLE
Mark thread safety spec as :no_rbs

### DIFF
--- a/spec/zxcvbn/thread_safety_spec.rb
+++ b/spec/zxcvbn/thread_safety_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'Thread safety' do
+RSpec.describe 'Thread safety', :no_rbs do
   let(:tester) { ZXCVBN_TESTER }
 
   describe 'concurrent Zxcvbn.test from N threads' do


### PR DESCRIPTION
## Context

The thread safety spec exercises live Ruby threading behaviour that the RBS type checker cannot verify.

## Changes

Add `:no_rbs` metadata to the `RSpec.describe 'Thread safety'` block.

## Consequences

The thread safety spec is excluded from RBS type-checking runs.